### PR TITLE
fixed: unbind moduleEventWatcher when deleting jvm plugin

### DIFF
--- a/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/src/main/java/com/alibaba/chaosblade/exec/bootstrap/jvmsandbox/SandboxModule.java
+++ b/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/src/main/java/com/alibaba/chaosblade/exec/bootstrap/jvmsandbox/SandboxModule.java
@@ -172,6 +172,11 @@ public class SandboxModule implements Module, ModuleLifecycle, PluginLifecycleLi
         if (plugin.getPointCut() == null) {
             return;
         }
-        watchIds.remove(PluginUtil.getIdentifier(plugin));
+        String identifier = PluginUtil.getIdentifier(plugin);
+        Integer watcherId = watchIds.get(identifier);
+        if (watcherId != null) {
+            moduleEventWatcher.delete(watcherId);
+        }
+        watchIds.remove(identifier);
     }
 }


### PR DESCRIPTION
Please review my code, thanks. You can find more info in:  #9 