### PR TITLE
refactor  model process flow when create or destroy injections

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/exception/ExperimentException.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/exception/ExperimentException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.chaosblade.exec.service.handler;
+package com.alibaba.chaosblade.exec.common.exception;
 
 /**
  * @author Changjun Xiao

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/handler/PreCreateInjectionModelHandler.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/handler/PreCreateInjectionModelHandler.java
@@ -1,0 +1,27 @@
+package com.alibaba.chaosblade.exec.common.model.handler;
+
+import com.alibaba.chaosblade.exec.common.exception.ExperimentException;
+import com.alibaba.chaosblade.exec.common.model.Model;
+
+/**
+ * Model Level Handler before create injections
+ *
+ * <p>Useful for  need do something on model level not action level when receive a create request </p>
+ * <p>
+ * For example,a module contains multiple actions, before invoke actions,we need do something,so you can make @{@link
+ * com.alibaba.chaosblade.exec.common.model.ModelSpec} implements this interface.
+ * </p>
+ *
+ * @author haibin
+ * @date 2019-04-19
+ */
+public interface PreCreateInjectionModelHandler {
+
+    /**
+     * Invoke before create injections
+     *
+     * @param model model object
+     * @throws ExperimentException throw if anything wrong
+     */
+    public void preCreate(Model model) throws ExperimentException;
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/handler/PreDestroyInjectionModelHandler.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/handler/PreDestroyInjectionModelHandler.java
@@ -1,0 +1,27 @@
+package com.alibaba.chaosblade.exec.common.model.handler;
+
+import com.alibaba.chaosblade.exec.common.exception.ExperimentException;
+import com.alibaba.chaosblade.exec.common.model.Model;
+
+/**
+ * Model Level Handler before destroy injections
+ *
+ * <p>Useful for  need do something on model level not action level when receive a destroy request </p>
+ * <p>
+ * For example,a module contains multiple actions, before invoke destroy actions,we need do something,so you can make
+ *
+ * @author haibin
+ * @{@link com.alibaba.chaosblade.exec.common.model.ModelSpec} implements this interface.
+ * </p>
+ * @date 2019-04-19
+ */
+public interface PreDestroyInjectionModelHandler {
+
+    /**
+     * Invoke before destroy injections
+     *
+     * @param model the model
+     * @throws ExperimentException throw if anything wrong
+     */
+    public void preDestroy(Model model) throws ExperimentException;
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
@@ -1,0 +1,37 @@
+package com.alibaba.chaosblade.exec.plugin.jvm;
+
+import com.alibaba.chaosblade.exec.common.exception.ExperimentException;
+import com.alibaba.chaosblade.exec.common.model.Model;
+import com.alibaba.chaosblade.exec.common.model.handler.PreCreateInjectionModelHandler;
+import com.alibaba.chaosblade.exec.common.model.handler.PreDestroyInjectionModelHandler;
+import com.alibaba.chaosblade.exec.common.plugin.MethodModelSpec;
+
+/**
+ * Jvm model spec
+ * <p>
+ * The jvm model plugin is used  for creating common java fault injections.
+ * </p>
+ * <p>
+ * For example
+ * <ul>
+ *  <li>inject any java methods</li>
+ *  <li>cause jvm oom</li>
+ * </ul>
+ * </p>
+ *
+ * @author haibin
+ * @date 2019-04-19
+ */
+public class JvmModelSpec extends MethodModelSpec implements PreCreateInjectionModelHandler,
+    PreDestroyInjectionModelHandler {
+
+    @Override
+    public void preDestroy(Model model) throws ExperimentException {
+        MethodPreInjectHandler.preHandleRecovery(model);
+    }
+
+    @Override
+    public void preCreate(Model model) throws ExperimentException {
+        MethodPreInjectHandler.preHandleInjection(model);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmPlugin.java
@@ -21,7 +21,6 @@ import com.alibaba.chaosblade.exec.common.aop.Plugin;
 import com.alibaba.chaosblade.exec.common.aop.PointCut;
 import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
 import com.alibaba.chaosblade.exec.common.model.ModelSpec;
-import com.alibaba.chaosblade.exec.common.plugin.MethodModelSpec;
 import com.alibaba.chaosblade.exec.common.plugin.MethodEnhancer;
 
 /**
@@ -36,7 +35,7 @@ public class JvmPlugin implements Plugin {
 
     @Override
     public ModelSpec getModelSpec() {
-        return new MethodModelSpec();
+        return new JvmModelSpec();
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/MethodPreInjectHandler.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/MethodPreInjectHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.chaosblade.exec.service.handler;
+package com.alibaba.chaosblade.exec.plugin.jvm;
 
 import com.alibaba.chaosblade.exec.common.aop.PluginBean;
 import com.alibaba.chaosblade.exec.common.aop.PluginLifecycleListener;
@@ -24,6 +24,7 @@ import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.NameClassMatcher;
 import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
 import com.alibaba.chaosblade.exec.common.aop.matcher.method.NameMethodMatcher;
 import com.alibaba.chaosblade.exec.common.center.ManagerFactory;
+import com.alibaba.chaosblade.exec.common.exception.ExperimentException;
 import com.alibaba.chaosblade.exec.common.model.Model;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.plugin.MethodConstant;
@@ -33,6 +34,7 @@ import com.alibaba.chaosblade.exec.common.plugin.MethodPlugin;
  * @author changjun.xcj
  */
 public class MethodPreInjectHandler {
+
     public static void preHandleInjection(Model model)
         throws ExperimentException {
         MethodPlugin methodPlugin = createMethodPlugin(model);


### PR DESCRIPTION
### Question?
In chaos-exec-service module,When create or destory injection,currently has special  logic for the jvm plugin,but  the module is common,so can't include any special logics for one plugin.
### How to resolve
So we need to avoid this and supply interfaces for plugin to extend. 
+ PreCreateInjectionModelHandler 
Model Level Handler before create injections
+ PreDestroyInjectionModelHandler 
Model Level Handler before destroy injections

