### PR TITLE
fixed: Numeric overflow in expression

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/action/threadpool/InterruptableRunnable.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/action/threadpool/InterruptableRunnable.java
@@ -5,7 +5,7 @@ package com.alibaba.chaosblade.exec.common.model.action.threadpool;
  */
 public class InterruptableRunnable implements Runnable {
 
-    public static final long MAX_SLEEP_TIME_IN_MILLS = 24 * 60 * 60 * 60 * 1000;
+    public static final long MAX_SLEEP_TIME_IN_MILLS = 24 * 60 * 60 * 60 * 1000L;
 
     @Override
     public void run() {


### PR DESCRIPTION
### Describe what this PR does / why we need it

A numeric overflow bug as described in the issue #28 

the value of this expression actually is 889032704.

### Describe how to verify it

Now the expression value is 5184000000
