### PR TITLE
feat: add cpu full load for jvm

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/pom.xml
@@ -39,6 +39,13 @@
         </plugins>
     </build>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
+    </dependencies>
 
 
 </project>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmConstant.java
@@ -21,4 +21,9 @@ public final class JvmConstant {
 
     public static String ACTION_OUT_OF_MEMORY_ERROR_ALIAS = "oom";
 
+    public static String ACTION_CPU_FULL_LOAD_NAME = "cpufullload";
+
+    public static String ACION_CPU_FULL_LOAD_ALIAS = "cfl";
+
+    public static String FLAG_NAME_CPU_COUNT = "cpu-count";
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
@@ -7,6 +7,7 @@ import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
 import com.alibaba.chaosblade.exec.common.model.handler.PreCreateInjectionModelHandler;
 import com.alibaba.chaosblade.exec.common.model.handler.PreDestroyInjectionModelHandler;
 import com.alibaba.chaosblade.exec.common.plugin.MethodModelSpec;
+import com.alibaba.chaosblade.exec.plugin.jvm.cpu.JvmCpuFullLoadActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.oom.JvmOomActionSpec;
 
 /**
@@ -31,6 +32,7 @@ public class JvmModelSpec extends MethodModelSpec implements PreCreateInjectionM
     public JvmModelSpec() {
         super();
         addActionSpec(new JvmOomActionSpec());
+        addActionSpec(new JvmCpuFullLoadActionSpec());
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/CpuCountFlagSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/CpuCountFlagSpec.java
@@ -1,0 +1,30 @@
+package com.alibaba.chaosblade.exec.plugin.jvm.cpu;
+
+import com.alibaba.chaosblade.exec.common.model.FlagSpec;
+import com.alibaba.chaosblade.exec.plugin.jvm.JvmConstant;
+
+/**
+ * @author Changjun Xiao
+ */
+public class CpuCountFlagSpec implements FlagSpec {
+
+    @Override
+    public String getName() {
+        return JvmConstant.FLAG_NAME_CPU_COUNT;
+    }
+
+    @Override
+    public String getDesc() {
+        return "Binding cpu core count";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/JvmCpuFullLoadActionSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/JvmCpuFullLoadActionSpec.java
@@ -1,0 +1,70 @@
+package com.alibaba.chaosblade.exec.plugin.jvm.cpu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.model.FlagSpec;
+import com.alibaba.chaosblade.exec.common.model.Model;
+import com.alibaba.chaosblade.exec.common.model.action.ActionModel;
+import com.alibaba.chaosblade.exec.common.model.action.BaseActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
+import com.alibaba.chaosblade.exec.plugin.jvm.JvmConstant;
+import com.alibaba.chaosblade.exec.plugin.jvm.StoppableActionExecutor;
+
+/**
+ * @author Changjun Xiao
+ */
+public class JvmCpuFullLoadActionSpec extends BaseActionSpec implements DirectlyInjectionAction {
+
+    public JvmCpuFullLoadActionSpec() {
+        super(new JvmCpuFullLoadExecutor());
+    }
+
+    @Override
+    public String getName() {
+        return JvmConstant.ACTION_CPU_FULL_LOAD_NAME;
+    }
+
+    @Override
+    public String[] getAliases() {
+        return new String[] {JvmConstant.ACION_CPU_FULL_LOAD_ALIAS};
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Process occupied cpu full load";
+    }
+
+    @Override
+    public String getLongDesc() {
+        return "Process occupied cpu full load";
+    }
+
+    @Override
+    public List<FlagSpec> getActionFlags() {
+        ArrayList<FlagSpec> flagSpecs = new ArrayList<FlagSpec>();
+        flagSpecs.add(new CpuCountFlagSpec());
+        return flagSpecs;
+    }
+
+    @Override
+    public PredicateResult predicate(ActionModel actionModel) {
+        return PredicateResult.success();
+    }
+
+    @Override
+    public void createInjection(String uid, Model model) throws Exception {
+        EnhancerModel enhancerModel = new EnhancerModel(EnhancerModel.class.getClassLoader(), model.getMatcher());
+        enhancerModel.merge(model);
+        getActionExecutor().run(enhancerModel);
+    }
+
+    @Override
+    public void destroyInjection(String uid, Model model) throws Exception {
+        EnhancerModel enhancerModel = new EnhancerModel(EnhancerModel.class.getClassLoader(), model.getMatcher());
+        enhancerModel.merge(model);
+        ((StoppableActionExecutor)getActionExecutor()).stop(enhancerModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/JvmCpuFullLoadExecutor.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/cpu/JvmCpuFullLoadExecutor.java
@@ -1,0 +1,76 @@
+package com.alibaba.chaosblade.exec.plugin.jvm.cpu;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.action.ActionExecutor;
+import com.alibaba.chaosblade.exec.common.util.StringUtil;
+import com.alibaba.chaosblade.exec.plugin.jvm.JvmConstant;
+import com.alibaba.chaosblade.exec.plugin.jvm.StoppableActionExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Changjun Xiao
+ */
+public class JvmCpuFullLoadExecutor implements ActionExecutor, StoppableActionExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvmCpuFullLoadExecutor.class);
+
+    private volatile ExecutorService executorService;
+    private Object lock = new Object();
+    private volatile boolean flag;
+
+    /**
+     * Through the infinite loop to achieve full CPU load.
+     *
+     * @param enhancerModel
+     * @throws Exception
+     */
+    @Override
+    public void run(EnhancerModel enhancerModel) throws Exception {
+        if (executorService != null && (!executorService.isShutdown())) {
+            throw new IllegalStateException("The jvm cpu full load experiment is running");
+        }
+        String cpuCount = enhancerModel.getActionFlag(JvmConstant.FLAG_NAME_CPU_COUNT);
+        int maxProcessors = Runtime.getRuntime().availableProcessors();
+        int threadCount = maxProcessors;
+        if (!StringUtil.isBlank(cpuCount)) {
+            Integer count = Integer.valueOf(cpuCount.trim());
+            if (count > 0 && count < maxProcessors) {
+                threadCount = count;
+            } else {
+                throw new IllegalArgumentException("cpu-count value is illegal: " + cpuCount);
+            }
+        }
+        synchronized (lock) {
+            if (executorService != null && (!executorService.isShutdown())) {
+                throw new IllegalStateException("The jvm cpu full load experiment is running...");
+            }
+            executorService = Executors.newFixedThreadPool(threadCount);
+        }
+        flag = true;
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    while (flag) {
+                    }
+                }
+            });
+            LOGGER.info("start jvm cpu full load thread, {}", i);
+        }
+    }
+
+    @Override
+    public void stop(EnhancerModel enhancerModel) throws Exception {
+        flag = false;
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdownNow();
+            executorService = null;
+            LOGGER.info("jvm cpu full load stopped");
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?
Feat #40 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Through the infinite loop to achieve CPU full load.
`--cpu-count` flag is cpu core number about full load, default is all cores.
Usage(You must execute prepare command first for jvm experiments):
`blade create jvm cfl`
`blade create jvm cpufullload`
`blade create jvm cfl --cpu-count 4`
