### PR TITLE
feature: add limits of request count and percent in effect

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/DefaultStatusManager.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/DefaultStatusManager.java
@@ -151,6 +151,21 @@ public class DefaultStatusManager implements StatusManager {
     }
 
     @Override
+    public StatusMetric getStatusMetricByUid(String uid) {
+        // get model identifier
+        String identifier = experiments.get(uid);
+        if (StringUtil.isBlank(identifier)) {
+            return null;
+        }
+        String target = ModelUtil.getTarget(identifier);
+        ConcurrentHashMap<String, StatusMetric> metricMap = models.get(target);
+        if (metricMap == null || metricMap.size() == 0) {
+            return null;
+        }
+        return metricMap.get(identifier);
+    }
+
+    @Override
     public void load() {
         closed = false;
     }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/StatusManager.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/StatusManager.java
@@ -72,4 +72,12 @@ public interface StatusManager extends ManagerService {
      */
     boolean expExists(String targetName);
 
+    /**
+     * Get status metric by uid
+     *
+     * @param uid
+     * @return
+     */
+    StatusMetric getStatusMetricByUid(String uid);
+
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/StatusMetric.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/StatusMetric.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.chaosblade.exec.common.center;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import com.alibaba.chaosblade.exec.common.model.Model;
 
 /**
@@ -23,12 +25,22 @@ import com.alibaba.chaosblade.exec.common.model.Model;
  */
 public class StatusMetric {
     private Model model;
+    private AtomicLong hitCounts;
 
     public StatusMetric(Model model) {
         this.model = model;
+        this.hitCounts = new AtomicLong(0);
     }
 
     public Model getModel() {
         return model;
+    }
+
+    public void increase() {
+        hitCounts.incrementAndGet();
+    }
+
+    public long getCount() {
+        return hitCounts.get();
     }
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
@@ -21,4 +21,14 @@ package com.alibaba.chaosblade.exec.common.constant;
  */
 public interface ModelConstant {
     String JVM_TARGET = "jvm";
+
+    /**
+     * The name of effect percent matcher
+     */
+    String EFFECT_PERCENT_MATCHER_NAME = "effect-percent";
+
+    /**
+     * The name of effect count matcher
+     */
+    String EFFECT_COUNT_MATCHER_NAME = "effect-count";
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/BaseModelSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/BaseModelSpec.java
@@ -24,6 +24,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
 import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
+import com.alibaba.chaosblade.exec.common.model.matcher.EffectCountMatcherSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.EffectPercentMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.prepare.AgentPrepareSpec;
 import com.alibaba.chaosblade.exec.common.model.prepare.PrepareSpec;
@@ -60,6 +63,12 @@ public abstract class BaseModelSpec implements ModelSpec {
         ActionSpec oldActionSpec = actionSpecs.putIfAbsent(actionSpec.getName(), actionSpec);
         if (oldActionSpec != null) {
             LOGGER.warn("{} action has defined in {} target model", actionSpec.getName(), getTarget());
+            return;
+        }
+        if (!(actionSpec instanceof DirectlyInjectionAction)) {
+            // add effect matcher
+            actionSpec.addMatcherDesc(new EffectCountMatcherSpec());
+            actionSpec.addMatcherDesc(new EffectPercentMatcherSpec());
         }
     }
 

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/EffectCountMatcherSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/EffectCountMatcherSpec.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.common.model.matcher;
+
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
+import com.alibaba.chaosblade.exec.common.util.StringUtil;
+
+/**
+ * @author Changjun Xiao
+ */
+public class EffectCountMatcherSpec implements MatcherSpec {
+
+    @Override
+    public String getName() {
+        return ModelConstant.EFFECT_COUNT_MATCHER_NAME;
+    }
+
+    @Override
+    public String getDesc() {
+        return "The count of chaos experiment in effect";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+
+    @Override
+    public PredicateResult predicate(MatcherModel matcherModel) {
+        String count = matcherModel.get(ModelConstant.EFFECT_COUNT_MATCHER_NAME);
+        if (!StringUtil.isBlank(count)) {
+            try {
+                Long.valueOf(count);
+            } catch (NumberFormatException e) {
+                return PredicateResult.fail(
+                    ModelConstant.EFFECT_COUNT_MATCHER_NAME + " value is illegal: " + count);
+            }
+        }
+        return PredicateResult.success();
+    }
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/EffectPercentMatcherSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/EffectPercentMatcherSpec.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.common.model.matcher;
+
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
+import com.alibaba.chaosblade.exec.common.util.StringUtil;
+
+/**
+ * @author Changjun Xiao
+ */
+public class EffectPercentMatcherSpec implements MatcherSpec {
+
+    @Override
+    public String getName() {
+        return ModelConstant.EFFECT_PERCENT_MATCHER_NAME;
+    }
+
+    @Override
+    public String getDesc() {
+        return "The percent of chaos experiment in effect";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+
+    @Override
+    public PredicateResult predicate(MatcherModel matcherModel) {
+        String percent = matcherModel.get(ModelConstant.EFFECT_PERCENT_MATCHER_NAME);
+        if (!StringUtil.isBlank(percent)) {
+            try {
+                Integer.valueOf(percent);
+            } catch (NumberFormatException e) {
+                return PredicateResult.fail(
+                    ModelConstant.EFFECT_PERCENT_MATCHER_NAME + " value is illegal: " + percent);
+            }
+        }
+        return PredicateResult.success();
+    }
+}

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/StatusHandler.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/StatusHandler.java
@@ -16,13 +16,23 @@
 
 package com.alibaba.chaosblade.exec.service.handler;
 
+import com.alibaba.chaosblade.exec.common.center.ManagerFactory;
+import com.alibaba.chaosblade.exec.common.center.StatusManager;
+import com.alibaba.chaosblade.exec.common.center.StatusMetric;
 import com.alibaba.chaosblade.exec.common.transport.Request;
 import com.alibaba.chaosblade.exec.common.transport.Response;
+import com.alibaba.chaosblade.exec.common.transport.Response.Code;
+import com.alibaba.chaosblade.exec.common.util.StringUtil;
 
 /**
  * @author Changjun Xiao
  */
 public class StatusHandler implements RequestHandler {
+    private StatusManager statusManager;
+
+    public StatusHandler() {
+        this.statusManager = ManagerFactory.getStatusManager();
+    }
 
     @Override
     public String getHandlerName() {
@@ -30,7 +40,15 @@ public class StatusHandler implements RequestHandler {
     }
 
     @Override
-    public Response handle(Request paramRequest) {
-        return Response.ofSuccess("success");
+    public Response handle(Request request) {
+        String suid = request.getParam("suid");
+        if (StringUtil.isBlank(suid)) {
+            return Response.ofFailure(Code.ILLEGAL_PARAMETER, "suid must not be empty");
+        }
+        StatusMetric statusMetric = statusManager.getStatusMetricByUid(suid);
+        if (statusMetric == null) {
+            return Response.ofFailure(Code.NOT_FOUND, "data not found");
+        }
+        return Response.ofSuccess(String.valueOf(statusMetric.getCount()));
     }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Limit the count of affected requests to control the impact.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Feature #46 

### Describe how you did it
1. Add `effect-count` and `effect-percent` matcher flags in all actions(exclude cpu full load and oom).
2. Add a check before the action is executed.

### Describe how to verify it
1. Verify the `effect-count` flag by comparing the number of triggers with the returned hit result(see https://github.com/chaosblade-io/chaosblade/issues/100).
2. Verify the `effect-percent` flag by comparing the error rate with the flag value through a stress test with throw exception experiment.
