### PR TITLE
feature: add javaHome flag to prepare spec

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/prepare/AgentPrepareSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/prepare/AgentPrepareSpec.java
@@ -56,6 +56,28 @@ public class AgentPrepareSpec implements PrepareSpec {
             }
         };
         flagSpecs.add(flagSpec);
+        FlagSpec javaHome = new FlagSpec() {
+            @Override
+            public String getName() {
+                return "javaHome";
+            }
+
+            @Override
+            public String getDesc() {
+                return "java home path";
+            }
+
+            @Override
+            public boolean noArgs() {
+                return false;
+            }
+
+            @Override
+            public boolean required() {
+                return false;
+            }
+        };
+        flagSpecs.add(javaHome);
         return flagSpecs;
     }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Because the chaosblade toolkit has add the `javaHome` flag in prepare jvm command, so add the flag to the project for adapt it.

### Does this pull request fix one issue?
See #52 
