### PR TITLE
Add unit tests for JavaUtils, Base64Util and SQLParserUtil

### DIFF
--- a/chaosblade-exec-common/src/tests/java/com/alibaba/chaosblade/exec/common/util/SQLParserUtilTest.java
+++ b/chaosblade-exec-common/src/tests/java/com/alibaba/chaosblade/exec/common/util/SQLParserUtilTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+public class SQLParserUtilTest {
+
+    @Test
+    public void testGetSqlType() throws SQLException {
+        Assert.assertNull(SQLParserUtil.getSqlType(""));
+        Assert.assertNull(SQLParserUtil.getSqlType("/*foo"));
+
+        Assert.assertEquals(0, SQLParserUtil.getSqlType("select").value());
+        Assert.assertEquals(1, SQLParserUtil.getSqlType("insert").value());
+        Assert.assertEquals(2, SQLParserUtil.getSqlType("update").value());
+        Assert.assertEquals(3, SQLParserUtil.getSqlType("delete").value());
+        Assert.assertEquals(5, SQLParserUtil.getSqlType("replace").value());
+        Assert.assertEquals(6, SQLParserUtil.getSqlType("truncate").value());
+        Assert.assertEquals(7, SQLParserUtil.getSqlType("create").value());
+        Assert.assertEquals(8, SQLParserUtil.getSqlType("drop").value());
+        Assert.assertEquals(9, SQLParserUtil.getSqlType("load").value());
+        Assert.assertEquals(10, SQLParserUtil.getSqlType("merge").value());
+        Assert.assertEquals(11, SQLParserUtil.getSqlType("show").value());
+    }
+
+    @Test
+    public void testFindTableName() {
+        Assert.assertNull(SQLParserUtil.findTableName(null));
+        Assert.assertNull(SQLParserUtil.findTableName("foo"));
+        Assert.assertNull(SQLParserUtil.findTableName("update %"));
+        Assert.assertNull(SQLParserUtil.findTableName("delete %"));
+        Assert.assertNull(SQLParserUtil.findTableName("insert %"));
+        Assert.assertNull(SQLParserUtil.findTableName("replace %"));
+        Assert.assertNull(SQLParserUtil.findTableName("foobarbaz"));
+        Assert.assertNull(SQLParserUtil.findTableName("select )from"));
+
+        Assert.assertEquals("foo", SQLParserUtil.findTableName("update foo"));
+        Assert.assertEquals("foo", SQLParserUtil.findTableName("delete foo"));
+        Assert.assertEquals("foo",
+                SQLParserUtil.findTableName("delete from foo"));
+        Assert.assertEquals("foo",
+                SQLParserUtil.findTableName("insert into foo"));
+        Assert.assertEquals("foo",
+                SQLParserUtil.findTableName("replace into foo"));
+        Assert.assertEquals("foo",
+                SQLParserUtil.findTableName("select from foo"));
+        Assert.assertEquals("foo",
+                SQLParserUtil.findTableName("select from foo"));
+        Assert.assertEquals("bar",
+                SQLParserUtil.findTableName("select from (foo,bar,baz) where "));
+        Assert.assertEquals("bar",
+                SQLParserUtil.findTableName("select foo)from bar"));
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/test/java/com/alibaba/chaosblade/exec/plugin/jvm/Base64UtilTest.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/test/java/com/alibaba/chaosblade/exec/plugin/jvm/Base64UtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jvm;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Base64UtilTest {
+
+    @Test
+    public void testEncode() {
+        Assert.assertEquals("", Base64Util.encode(new byte[0], true));
+        Assert.assertEquals("", Base64Util.encode(new byte[0], false));
+        Assert.assertEquals("AQID",
+                Base64Util.encode(new byte[]{1, 2, 3}, true));
+        Assert.assertEquals("AQID",
+                Base64Util.encode(new byte[]{1, 2, 3}, false));
+    }
+
+    @Test
+    public void testDecode() {
+        Assert.assertEquals("", Base64Util.decode(new byte[0]));
+        Assert.assertEquals("", Base64Util.decode(new byte[]{0, 10}));
+        Assert.assertEquals("", Base64Util.decode(new byte[]{1, 2, 13, 10}));
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/test/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaUtilsTest.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/test/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jvm.script.java;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaUtilsTest {
+
+    @Test
+    public void testGetClassName() {
+        Assert.assertEquals("", JavaUtils.getClassName(""));
+        Assert.assertEquals("", JavaUtils.getClassName("String"));
+        Assert.assertEquals("", JavaUtils.getClassName("classString"));
+        Assert.assertEquals("", JavaUtils.getClassName("class.String"));
+        Assert.assertEquals("String", JavaUtils.getClassName("classString%"));
+    }
+
+    @Test
+    public void testIsAsciiAlpha() {
+        Assert.assertTrue(JavaUtils.isAsciiAlpha('B'));
+        Assert.assertTrue(JavaUtils.isAsciiAlpha('b'));
+
+        Assert.assertFalse(JavaUtils.isAsciiAlpha('%'));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.alibaba.chaosblade.exec.plugin.jvm.script.java.JavaUtils`, `com.alibaba.chaosblade.exec.plugin.jvm.Base64Util` and `com.alibaba.chaosblade.exec.common.util.SQLParserUtil`  is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.