### PR TITLE
servlet plugin: add requestpath flag

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletEnhancer.java
@@ -16,16 +16,16 @@
 
 package com.alibaba.chaosblade.exec.plugin.servlet;
 
-import java.lang.reflect.Method;
-
 import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
+import com.alibaba.chaosblade.exec.common.util.StringUtils;
 import com.alibaba.fastjson.JSON;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
 
 /**
  * @author Changjun Xiao
@@ -43,12 +43,15 @@ public class ServletEnhancer extends BeforeEnhancer {
         String queryString = ReflectUtil.invokeMethod(request, "getQueryString", new Object[] {}, false);
         String servletPath = ReflectUtil.invokeMethod(request, "getServletPath", new Object[] {}, false);
         String requestMethod = ReflectUtil.invokeMethod(request, "getMethod", new Object[] {}, false);
+        // RequestUri without ContextPath
+        String requestPath = StringUtils.isNotBlank(pathInfo) ? servletPath + pathInfo : servletPath;
 
         MatcherModel matcherModel = new MatcherModel();
         matcherModel.add(ServletConstant.PATH_INFO_KEY, pathInfo);
         matcherModel.add(ServletConstant.QUERY_STRING_KEY, queryString);
         matcherModel.add(ServletConstant.SERVLET_PATH_KEY, servletPath);
         matcherModel.add(ServletConstant.METHOD_KEY, requestMethod);
+        matcherModel.add(ServletConstant.REQUEST_PATH_KEY, requestPath);
 
         LOOGER.info("servlet matchers: {}", JSON.toJSONString(matcherModel));
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletModelSpec.java
@@ -54,6 +54,7 @@ public class ServletModelSpec extends FrameworkModelSpec {
         matcherSpecs.add(new ServletQueryStringMatcherSpec());
         matcherSpecs.add(new ServletPathMatcherSpec());
         matcherSpecs.add(new ServletMethodMatcherSpec());
+        matcherSpecs.add(new ServletRequestPathMatcherSpec());
         return matcherSpecs;
     }
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletRequestPathMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/src/main/java/com/alibaba/chaosblade/exec/plugin/servlet/ServletRequestPathMatcherSpec.java
@@ -16,16 +16,28 @@
 
 package com.alibaba.chaosblade.exec.plugin.servlet;
 
-/**
- * @author Changjun Xiao
- */
-public interface ServletConstant {
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
 
-    String PATH_INFO_KEY = "pathinfo";
-    String QUERY_STRING_KEY = "querystring";
-    String SERVLET_PATH_KEY = "servletpath";
-    String METHOD_KEY = "method";
-    String REQUEST_PATH_KEY = "requestpath";
+public class ServletRequestPathMatcherSpec extends BasePredicateMatcherSpec {
 
-    String TARGET_NAME = "servlet";
+    @Override
+    public String getName() {
+        return ServletConstant.REQUEST_PATH_KEY;
+    }
+
+    @Override
+    public String getDesc() {
+        return "equal RequestUri without ContextPath";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
1.chaosblade-exec-plugin-servlet adds requestpath flag
The values of servletpath and pathinfo are affected by the web.xml configuration. It is not easy to get the correct value when using it. Added requestpath flag, which is equivalent to requesturi without contextpath.

### Does this pull request fix one issue?
https://github.com/chaosblade-io/chaosblade/issues/134

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
join servletpath and pathinfo

### Describe how to verify it


### Special notes for reviews
