### PR TITLE
Add support for jvm code cache full

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmConstant.java
@@ -39,6 +39,10 @@ public interface JvmConstant {
 
     String ACTION_CPU_FULL_LOAD_ALIAS = "cfl";
 
+    String ACTION_CODE_CACHE_FILLING_NAME = "CodeCacheFilling";
+
+    String ACTION_CODE_CACHE_FILLING_ALIAS = "ccf";
+
     String FLAG_NAME_CPU_COUNT = "cpu-count";
 
     String ACTION_DYNAMIC_SCRIPT_NAME = "script";

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
@@ -25,6 +25,7 @@ import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
 import com.alibaba.chaosblade.exec.common.model.handler.PreCreateInjectionModelHandler;
 import com.alibaba.chaosblade.exec.common.model.handler.PreDestroyInjectionModelHandler;
 import com.alibaba.chaosblade.exec.common.plugin.MethodModelSpec;
+import com.alibaba.chaosblade.exec.plugin.jvm.codecache.CodeCacheFillingActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.cpu.JvmCpuFullLoadActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.oom.JvmOomActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.script.model.JvmDynamicActionSpec;
@@ -53,6 +54,7 @@ public class JvmModelSpec extends MethodModelSpec implements PreCreateInjectionM
         addActionSpec(new JvmOomActionSpec());
         addActionSpec(new JvmCpuFullLoadActionSpec());
         addActionSpec(new JvmDynamicActionSpec());
+        addActionSpec(new CodeCacheFillingActionSpec());
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/CodeCacheFillingActionSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/CodeCacheFillingActionSpec.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jvm.codecache;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.model.FlagSpec;
+import com.alibaba.chaosblade.exec.common.model.Model;
+import com.alibaba.chaosblade.exec.common.model.action.ActionModel;
+import com.alibaba.chaosblade.exec.common.model.action.BaseActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
+import com.alibaba.chaosblade.exec.plugin.jvm.JvmConstant;
+import com.alibaba.chaosblade.exec.plugin.jvm.StoppableActionExecutor;
+
+/**
+ * @author Jinglei Li
+ * @date 2019-07-31
+ * @mail liwx2000@gmail.com
+ */
+public class CodeCacheFillingActionSpec extends BaseActionSpec implements DirectlyInjectionAction {
+
+    public CodeCacheFillingActionSpec() {
+        super(new CodeCacheFillingExecutor());
+    }
+
+    @Override
+    public String getName() {
+        return JvmConstant.ACTION_CODE_CACHE_FILLING_NAME;
+    }
+
+    @Override
+    public String[] getAliases() {
+        return new String[] {JvmConstant.ACTION_CODE_CACHE_FILLING_ALIAS};
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "Fill up code cache.";
+    }
+
+    @Override
+    public String getLongDesc() {
+        return "Filling code cache until JIT compiler turn off.";
+    }
+
+    @Override
+    public List<FlagSpec> getActionFlags() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public PredicateResult predicate(ActionModel actionModel) {
+        return PredicateResult.success();
+    }
+
+    @Override
+    public void createInjection(String uid, Model model) throws Exception {
+        EnhancerModel enhancerModel = new EnhancerModel(EnhancerModel.class.getClassLoader(), model.getMatcher());
+        enhancerModel.merge(model);
+        getActionExecutor().run(enhancerModel);
+    }
+
+    @Override
+    public void destroyInjection(String uid, Model model) throws Exception {
+        EnhancerModel enhancerModel = new EnhancerModel(EnhancerModel.class.getClassLoader(), model.getMatcher());
+        enhancerModel.merge(model);
+        ((StoppableActionExecutor)getActionExecutor()).stop(enhancerModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/CodeCacheFillingExecutor.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/CodeCacheFillingExecutor.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jvm.codecache;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.action.ActionExecutor;
+import com.alibaba.chaosblade.exec.plugin.jvm.StoppableActionExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jinglei Li
+ * @date 2019-07-31
+ * @mail liwx2000@gmail.com
+ */
+public class CodeCacheFillingExecutor implements ActionExecutor, StoppableActionExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("CodeCacheFilling");
+
+    private static final String MEMORY_POOL_CODE_CACHE = "Code Cache";
+
+    private static final String COMPILE_THRESHOLD = "-XX:CompileThreshold"; //default: 10000
+
+    private static final int GENERATE_OBJECT_COUNT = 40;
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    private ExecutorService workers;
+
+    private Thread monitor;
+
+    @Override
+    public void run(EnhancerModel enhancerModel) {
+        if (started.get() || !started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Experiment is running. Please stop the experiment before re-run.");
+        }
+
+        if (null != workers && !workers.isShutdown()) {
+            workers.shutdown();
+            workers = null;
+        }
+
+        try {
+            int processors = Runtime.getRuntime().availableProcessors();
+            int compileThreshold = getCompileThreshold();
+            int bucketSize = GENERATE_OBJECT_COUNT / processors;
+
+            CyclicBarrier cyclicBarrier = new CyclicBarrier(processors + 1);
+
+            workers = Executors.newFixedThreadPool(processors);
+            monitor = new Thread(new CodeCacheMonitorRunnable(cyclicBarrier, started));
+
+            monitor.start();
+
+            for (int n = 0; n < processors; n++) {
+                workers.submit(new CodeCacheObjectPreheatingRunnable(bucketSize, compileThreshold, cyclicBarrier, started));
+            }
+        } catch (Throwable e) {
+            LOGGER.error("Unknown Error.", e);
+            started.compareAndSet(true, false);
+        }
+    }
+
+    private int getCompileThreshold() {
+        int threshold = 10000;
+
+        List<String> arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        for (String argument : arguments) {
+            if (argument.startsWith(COMPILE_THRESHOLD)) {
+                String[] pair = argument.split("=");
+                if (pair.length == 2 && null != pair[1] && pair[1].length() > 0) {
+                    int value = Integer.parseInt(pair[1]);
+                    if (value > 0) {
+                        threshold = value;
+                    }
+                    break;
+                }
+            }
+        }
+
+        return threshold;
+    }
+
+    @Override
+    public void stop(EnhancerModel enhancerModel) {
+        try {
+            if (null != monitor) {
+                if (monitor.isAlive()) {
+                    monitor.interrupt();
+                }
+                monitor = null;
+            }
+
+            if (null != workers) {
+                if (!workers.isShutdown()) {
+                    workers.shutdown();
+                }
+                workers = null;
+            }
+        } finally {
+            started.set(false);
+        }
+    }
+
+    static class CodeCacheObjectPreheatingRunnable implements Runnable {
+
+        private final int bucketSize;
+
+        private final int compileThreshold;
+
+        private final CyclicBarrier lock;
+
+        private final AtomicBoolean flag;
+
+        CodeCacheObjectPreheatingRunnable(int bucketSize, int compileThreshold, CyclicBarrier lock, AtomicBoolean flag) {
+            this.bucketSize = bucketSize;
+            this.compileThreshold = compileThreshold;
+            this.lock = lock;
+            this.flag = flag;
+        }
+
+        @Override
+        public void run() {
+            LOGGER.info("Generating all objects for preheating. Bucket size: " + bucketSize + ".");
+
+            List<Object> objects = new ArrayList<Object>();
+            DynamicJavaClassGenerator generator = new DynamicJavaClassGenerator();
+            for (int i = 0; i < bucketSize; i++) {
+                if (!flag.get()) {
+                    LOGGER.info("Experiment stopped. Stop code cache object generating.");
+                }
+
+                Object object = null;
+
+                try {
+                    object = generator.generateObject();
+                } catch (Exception e) {
+                    LOGGER.error("Generate CodeCacheObject failed.", e);
+                }
+
+                if (null != object) {
+                    objects.add(object);
+                }
+            }
+
+            LOGGER.info("Generated all objects for code cache filling.");
+
+            try {
+                lock.await();
+            } catch (Exception e) {
+                LOGGER.error("Worker thread has been interrupted.", e);
+                return;
+            }
+
+            LOGGER.info("Preheating all objects. Compile threshold: " + compileThreshold + ".");
+
+            while (true) {
+                for (Object object : objects) {
+                    try {
+                        Method method = object.getClass().getMethod("method");
+                        for (int i = 0; i <= compileThreshold; i++) {
+                            if (!flag.get()) {
+                                LOGGER.info("Experiment stopped. Stop code cache object preheating.");
+                                return;
+                            }
+                            method.invoke(object);
+                        }
+                    } catch (Exception e) {
+                        LOGGER.error("Preheating CodeCacheObject failed.", e);
+                    }
+                }
+            }
+        }
+
+    }
+
+    static class CodeCacheMonitorRunnable implements Runnable {
+
+        private final CyclicBarrier lock;
+
+        private final AtomicBoolean flag;
+
+        CodeCacheMonitorRunnable(CyclicBarrier lock, AtomicBoolean flag) {
+            this.lock = lock;
+            this.flag = flag;
+        }
+
+        @Override
+        public void run() {
+            try {
+                lock.await();
+            } catch (Exception e) {
+                LOGGER.error("Monitor thread has been interrupted.", e);
+                return;
+            }
+
+            int count = 0;
+            long latestUsed = 0;
+
+            while(flag.get()) {
+                MemoryUsage usage = getCodeCacheUsage();
+
+                LOGGER.debug("Code cache usage: " + usage);
+
+                if (null == usage) {
+                    LOGGER.warn("Can't get code cache memory usage. Stop code cache monitor.");
+                    break;
+                }
+
+                long used = usage.getUsed();
+
+                if (latestUsed == used) {
+                    count++;
+                } else {
+                    count = 0;
+                    latestUsed = used;
+                }
+
+                if (count > 5) {
+                    LOGGER.info("Code cache may be full. Will stop the experiment.");
+                    flag.compareAndSet(true, false);
+                }
+
+                try {
+                    TimeUnit.SECONDS.sleep(1L);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+
+        private MemoryUsage getCodeCacheUsage() {
+            List<MemoryPoolMXBean> memoryPoolMXBeans = ManagementFactory.getMemoryPoolMXBeans();
+            for (MemoryPoolMXBean memoryPoolMXBean : memoryPoolMXBeans) {
+                if (MEMORY_POOL_CODE_CACHE.equals(memoryPoolMXBean.getName())) {
+                    return memoryPoolMXBean.getUsage();
+                }
+            }
+            return null;
+        }
+    }
+
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/DynamicJavaClassGenerator.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/codecache/DynamicJavaClassGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jvm.codecache;
+
+import java.util.UUID;
+
+import com.alibaba.chaosblade.exec.plugin.jvm.script.base.CompiledScript;
+import com.alibaba.chaosblade.exec.plugin.jvm.script.base.DefaultScriptEngineService;
+import com.alibaba.chaosblade.exec.plugin.jvm.script.base.Script;
+import com.alibaba.chaosblade.exec.plugin.jvm.script.model.ScriptTypeEnum;
+
+/**
+ * @author Jinglei Li
+ * @date 2019-07-31
+ * @mail liwx2000@gmail.com
+ */
+public class DynamicJavaClassGenerator {
+
+    private static final int METHOD_COUNT_IN_CLASS = 16000;
+
+    private static final String CLASS_NAME_PREFIX = "CodeCacheFillingObject";
+
+    private static final DefaultScriptEngineService engineService = new DefaultScriptEngineService();
+
+    static {
+        engineService.initialize();
+    }
+
+    public Object generateObject() throws IllegalAccessException, InstantiationException {
+        String suffix = UUID.randomUUID().toString().replaceAll("-", "");
+        String className = CLASS_NAME_PREFIX + suffix;
+        String content = generateJavaClassSourceCode(className);
+
+        Script script = new Script(className, "", className, content, ScriptTypeEnum.JAVA.getName());
+        CompiledScript compiledScript = engineService.compile(Thread.currentThread().getContextClassLoader(), script, null);
+
+        Object compiled = compiledScript.getCompiled();
+        if (null != compiled) {
+            return ((Class<?>) compiled).newInstance();
+        }
+
+        return null;
+    }
+
+    private String generateJavaClassSourceCode(String className) {
+        return "public class " + className + "{\n" + generateMethods() + "}";
+    }
+
+    private String generateMethods() {
+        StringBuilder rootMethod = new StringBuilder("public void method() {\n");
+        StringBuilder methods = new StringBuilder();
+
+        for (int i = 0; i < METHOD_COUNT_IN_CLASS; i++) {
+            String methodName = "method" + i;
+
+            methods.append("public void ")
+                .append(methodName)
+                .append("() {}\n");
+
+            rootMethod.append(methodName)
+                .append("();\n");
+        }
+
+        rootMethod.append("}\n");
+
+        return methods.append(rootMethod).toString();
+    }
+
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaUtils.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaUtils.java
@@ -39,7 +39,7 @@ public class JavaUtils {
                     endIndex = i;
                 }
             } else {
-                if (!isAsciiAlpha(chars[i])) {
+                if (!(isAsciiAlpha(chars[i]) || isDigital(chars[i]))) {
                     endIndex = i;
                     break;
                 }
@@ -52,7 +52,7 @@ public class JavaUtils {
         return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
     }
 
-    public static void main(String[] args) {
-
+    public static boolean isDigital(char ch) {
+        return ch >= '0' && ch <= '9';
     }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Code cache is memory area for store code of JNI or jit compiled. Jit compiler will be disabled when code cache is full. Code cache full is a scenario which make system running slow down.

How to use:

> blade p jvm --process xxx
> blade create jvm CodeCacheFilling

