### PR TITLE
fix:解决javacompile会导致SharedNameTable内存泄露的问题

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaCodeScriptEngine.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaCodeScriptEngine.java
@@ -144,7 +144,7 @@ public class JavaCodeScriptEngine implements ScriptEngine {
         JavaFileObject javaFileObject = new InputStringJavaFileObject(className, content);
         StandardJavaFileManager standardFileManager = javaCompiler.getStandardFileManager(null, null, CHARSET_UTF8);
         InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(classLoader, standardFileManager);
-        JavaCompiler.CompilationTask compilationTask = javaCompiler.getTask(null, fileManager, diagnostics, null, null,
+        JavaCompiler.CompilationTask compilationTask = javaCompiler.getTask(null, fileManager, diagnostics, Arrays.asList("-XDuseUnsharedTable"), null,
             Arrays.asList(javaFileObject));
         if (Boolean.TRUE.equals(compilationTask.call())) {
             try {


### PR DESCRIPTION
参考链接: https://blog.csdn.net/qq_42914528/article/details/81538321

在持续编译class的时候, 会导致SharedNameTable变多并且无法释放
![image](https://user-images.githubusercontent.com/5414568/99780171-10da0100-2b51-11eb-9dac-f90ca72f064b.png)

![image](https://user-images.githubusercontent.com/5414568/99780454-77f7b580-2b51-11eb-8a3a-6f8bb9991c47.png)

