### PR TITLE
Support chaos experiments for log framework

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/matcher/clazz/AndClassMatcher.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/matcher/clazz/AndClassMatcher.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.common.aop.matcher.clazz;
+
+import com.alibaba.chaosblade.exec.common.aop.matcher.ClassInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class AndClassMatcher implements ClassMatcher {
+
+    private final List<ClassMatcher> matchers = new ArrayList<ClassMatcher>(2);
+
+    /**
+     * Add other class matcher with and relation
+     *
+     * @param matcher
+     * @return
+     */
+    public AndClassMatcher and(ClassMatcher matcher) {
+        if (matcher != null) {
+            matchers.add(matcher);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean isMatched(String className, ClassInfo classInfo) {
+        for (ClassMatcher matcher : matchers) {
+            if (!matcher.isMatched(className, classInfo)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
@@ -127,11 +127,13 @@ public class Injector {
         }
         MatcherModel enhancerMatcherModel = enhancerModel.getMatcherModel();
         if (enhancerMatcherModel == null) {
+            LOGGER.debug("enhancerMatcherModel is null, match fail");
             return false;
         }
         Map<String, Object> matchers = matcher.getMatchers();
         for (Entry<String, Object> entry : matchers.entrySet()) {
             String keyName = entry.getKey();
+            LOGGER.debug("match key:{} beginning...", keyName);
             // filter effect count and effect percent
             if (keyName.equalsIgnoreCase(ModelConstant.EFFECT_COUNT_MATCHER_NAME) ||
                     keyName.equalsIgnoreCase(ModelConstant.EFFECT_PERCENT_MATCHER_NAME)) {
@@ -140,6 +142,7 @@ public class Injector {
 
             Object value = enhancerMatcherModel.get(keyName);
             if (value == null) {
+                LOGGER.debug("match key:{}, value is null, match fail", keyName);
                 return false;
             }
 
@@ -147,6 +150,7 @@ public class Injector {
             if (customMatcher == null) {
                 // default match
                 if (String.valueOf(value).equalsIgnoreCase(String.valueOf(entry.getValue()))) {
+                    LOGGER.debug("custom match key:{}, value equals, continue", keyName);
                     continue;
                 }
 
@@ -166,6 +170,7 @@ public class Injector {
             if (keyName.endsWith(ModelConstant.REGEX_PATTERN_FLAG) ? customMatcher.regexMatch(String.valueOf(entry.getValue()), value) : customMatcher.match(String.valueOf(entry.getValue()), value)) {
                 continue;
             }
+            LOGGER.debug("match key:{} fail", keyName);
             return false;
         }
         return true;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>chaosblade-exec-plugin</artifactId>
+        <groupId>com.alibaba.chaosblade</groupId>
+        <version>1.2.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>chaosblade-exec-plugin-log</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>6</source>
+                    <target>6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/LogConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/LogConstant.java
@@ -1,0 +1,10 @@
+package com.alibaba.chaosblade.exec.plugin.log;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public interface LogConstant {
+    String TARGET = "log";
+
+    String LOGBACK_KEY = "logback";
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/LogPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/LogPlugin.java
@@ -1,0 +1,15 @@
+package com.alibaba.chaosblade.exec.plugin.log;
+
+import com.alibaba.chaosblade.exec.common.aop.Plugin;
+import com.alibaba.chaosblade.exec.common.model.ModelSpec;
+import com.alibaba.chaosblade.exec.plugin.log.model.LogModelSpec;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public abstract class LogPlugin implements Plugin {
+    @Override
+    public ModelSpec getModelSpec() {
+        return new LogModelSpec();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackEnhancer.java
@@ -1,0 +1,23 @@
+package com.alibaba.chaosblade.exec.plugin.log.logback;
+
+import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class LogbackEnhancer extends BeforeEnhancer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogbackEnhancer.class);
+
+    @Override
+    public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments) throws Exception {
+        LOGGER.info("logback do before, classLoader:{}, className:{}, object:{}, method:{}, args:{}", classLoader, className, object, method.getName(), methodArguments);
+
+        return new EnhancerModel(classLoader, new MatcherModel());
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackEnhancer.java
@@ -3,6 +3,7 @@ package com.alibaba.chaosblade.exec.plugin.log.logback;
 import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import com.alibaba.chaosblade.exec.plugin.log.LogConstant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +19,8 @@ public class LogbackEnhancer extends BeforeEnhancer {
     public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments) throws Exception {
         LOGGER.info("logback do before, classLoader:{}, className:{}, object:{}, method:{}, args:{}", classLoader, className, object, method.getName(), methodArguments);
 
-        return new EnhancerModel(classLoader, new MatcherModel());
+        EnhancerModel enhancerModel = new EnhancerModel(classLoader, new MatcherModel());
+        enhancerModel.addMatcher(LogConstant.LOGBACK_KEY, "true");
+        return enhancerModel;
     }
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackPlugin.java
@@ -1,0 +1,26 @@
+package com.alibaba.chaosblade.exec.plugin.log.logback;
+
+import com.alibaba.chaosblade.exec.common.aop.Enhancer;
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.plugin.log.LogConstant;
+import com.alibaba.chaosblade.exec.plugin.log.LogPlugin;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class LogbackPlugin extends LogPlugin {
+    @Override
+    public String getName() {
+        return LogConstant.LOGBACK_KEY;
+    }
+
+    @Override
+    public PointCut getPointCut() {
+        return new LogbackPointCut();
+    }
+
+    @Override
+    public Enhancer getEnhancer() {
+        return new LogbackEnhancer();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/logback/LogbackPointCut.java
@@ -1,0 +1,36 @@
+package com.alibaba.chaosblade.exec.plugin.log.logback;
+
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.*;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.NameMethodMatcher;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class LogbackPointCut implements PointCut {
+    private static final String LOGBACK_CONSOLE_STREAM_SYS_OUT = "ch.qos.logback.core.joran.spi.ConsoleTarget$1";
+    private static final String LOGBACK_CONSOLE_STREAM_SYS_ERROR = "ch.qos.logback.core.joran.spi.ConsoleTarget$2";
+    private static final String JAVA_OUTPUT_STREAM = "java.io.OutputStream";
+    private static final String LOGBACK_FILE_OUTPUT_STREAM = "ch.qos.logback.core.recovery.ResilientOutputStreamBase";
+    private static final String LOGBACK_METHOD_NAME = "flush";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        ClassMatcher consoleTargetClassNameMatcher = new OrClassMatcher()
+                .or(new NameClassMatcher(LOGBACK_CONSOLE_STREAM_SYS_OUT))
+                .or(new NameClassMatcher(LOGBACK_CONSOLE_STREAM_SYS_ERROR));
+        ClassMatcher consoleMatcher = new AndClassMatcher()
+                .and(new SuperClassMatcher(JAVA_OUTPUT_STREAM))
+                .and(consoleTargetClassNameMatcher);
+        ClassMatcher logbackAllClassMatcher = new OrClassMatcher()
+                .or(new NameClassMatcher(LOGBACK_FILE_OUTPUT_STREAM))
+                .or(consoleMatcher);
+        return logbackAllClassMatcher;
+    }
+
+    @Override
+    public MethodMatcher getMethodMatcher() {
+        return new NameMethodMatcher(LOGBACK_METHOD_NAME);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogModelSpec.java
@@ -1,0 +1,53 @@
+package com.alibaba.chaosblade.exec.plugin.log.model;
+
+import com.alibaba.chaosblade.exec.common.model.FrameworkModelSpec;
+import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.delay.DelayActionSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.log.LogConstant;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class LogModelSpec extends FrameworkModelSpec {
+
+    public LogModelSpec() {
+        addActionExample();
+    }
+
+    private void addActionExample() {
+        List<ActionSpec> actions = getActions();
+        for (ActionSpec action : actions) {
+            if (action instanceof DelayActionSpec) {
+                action.setLongDesc("Log framework delay experiment");
+                action.setExample("# Do a delay 1s experiment take effect 100 times\n" +
+                        "blade create log delay --logback --time 1000 --effect-count 100\n");
+            }
+        }
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "log experiment";
+    }
+
+    @Override
+    public String getLongDesc() {
+        return "log experiment for testing service delay.";
+    }
+
+    @Override
+    protected List<MatcherSpec> createNewMatcherSpecs() {
+        ArrayList<MatcherSpec> matcherSpecs = new ArrayList<MatcherSpec>();
+        matcherSpecs.add(new LogbackModelSpec());
+        return matcherSpecs;
+    }
+
+    @Override
+    public String getTarget() {
+        return LogConstant.TARGET;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogbackModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogbackModelSpec.java
@@ -1,0 +1,29 @@
+package com.alibaba.chaosblade.exec.plugin.log.model;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.log.LogConstant;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class LogbackModelSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return LogConstant.LOGBACK_KEY;
+    }
+
+    @Override
+    public String getDesc() {
+        return "To tag logback experiment.";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogbackModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/java/com/alibaba/chaosblade/exec/plugin/log/model/LogbackModelSpec.java
@@ -19,7 +19,7 @@ public class LogbackModelSpec extends BasePredicateMatcherSpec {
 
     @Override
     public boolean noArgs() {
-        return false;
+        return true;
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-log/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2019 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.chaosblade.exec.plugin.log.logback.LogbackPlugin

--- a/chaosblade-exec-plugin/pom.xml
+++ b/chaosblade-exec-plugin/pom.xml
@@ -45,6 +45,7 @@
         <module>chaosblade-exec-plugin-redisson</module>
         <module>chaosblade-exec-plugin-lettuce</module>
         <module>chaosblade-exec-plugin-kafka</module>
+        <module>chaosblade-exec-plugin-log</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
### Describe what this PR does / why we need it
支持日志框架的故障演练，例如delay、throw exception：
```
blade create log delay --logback --time 1000 --effect-count 100

blade create log throwCustomException --logback --exception java.lang.NullPointException
```

### Does this pull request fix one issue?

Fixes #179 
