### PR TITLE
Support Dubbo/HTTP call point match and fix Dubbo generalization invoke methodname bug

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboConstant.java
@@ -37,4 +37,6 @@ public interface DubboConstant {
     String CONSUMER_KEY = "consumer";
     String PROVIDER_KEY = "provider";
 
+    String CALL_POINT_KEY = "call-point";
+
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/consumer/DubboConsumerEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/consumer/DubboConsumerEnhancer.java
@@ -26,7 +26,7 @@ import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import com.alibaba.chaosblade.exec.common.util.StringUtils;
 import com.alibaba.chaosblade.exec.plugin.dubbo.DubboConstant;
 import com.alibaba.chaosblade.exec.plugin.dubbo.DubboEnhancer;
-
+import com.alibaba.chaosblade.exec.plugin.dubbo.model.CallPointMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,6 +107,8 @@ public class DubboConsumerEnhancer extends DubboEnhancer {
     @Override
     protected void postDoBeforeAdvice(EnhancerModel enhancerModel) {
         enhancerModel.addMatcher(DubboConstant.CONSUMER_KEY, "true");
+        StackTraceElement[] stackTrace = new NullPointerException().getStackTrace();
+        enhancerModel.addCustomMatcher(DubboConstant.CALL_POINT_KEY, stackTrace, CallPointMatcher.getInstance());
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/CallPointMatcher.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/CallPointMatcher.java
@@ -1,0 +1,58 @@
+package com.alibaba.chaosblade.exec.plugin.dubbo.model;
+
+import com.alibaba.chaosblade.exec.common.aop.CustomMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class CallPointMatcher implements CustomMatcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CallPointMatcher.class);
+    private static final CallPointMatcher INSTANCE = new CallPointMatcher();
+
+    private CallPointMatcher() {}
+
+    public static CallPointMatcher getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean match(String commandValue, Object originValue) {
+        // match the class and method name who send the request.
+        try {
+            if (commandValue == null || commandValue.isEmpty()) {
+                LOGGER.debug("commandValue is null, match success, commandValue:{}", commandValue);
+                return true;
+            }
+            if (originValue == null) {
+                LOGGER.debug("originValue is null, match fail, commandValue:{}", commandValue);
+                return false;
+            }
+            StackTraceElement[] stackTrace = (StackTraceElement[])originValue;
+            if (stackTrace.length == 0) {
+                LOGGER.debug("stackTrace length is zero, match fail, commandValue:{}", commandValue);
+                return false;
+            }
+            for (StackTraceElement element : stackTrace) {
+                String callPoint = buildCallPoint(element);
+                if (commandValue.equalsIgnoreCase(callPoint)) {
+                    LOGGER.debug("call point equals, match success, commandValue:{}", commandValue);
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("match call point fail, commandValue:{}, originValue:{}", commandValue, originValue, e);
+        }
+        return false;
+    }
+
+    private String buildCallPoint(StackTraceElement element) {
+        return element.getClassName() + "|" + element.getMethodName();
+    }
+
+    @Override
+    public boolean regexMatch(String commandValue, Object originValue) {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/CallPointMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/CallPointMatcherSpec.java
@@ -1,0 +1,29 @@
+package com.alibaba.chaosblade.exec.plugin.dubbo.model;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.dubbo.DubboConstant;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class CallPointMatcherSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return DubboConstant.CALL_POINT_KEY;
+    }
+
+    @Override
+    public String getDesc() {
+        return "the class and method name who send the request";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/DubboModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/DubboModelSpec.java
@@ -88,6 +88,7 @@ public class DubboModelSpec extends FrameworkModelSpec implements PreCreateInjec
         matcherSpecs.add(new VersionMatcherSpec());
         matcherSpecs.add(new MethodNameMatcherSpec());
         matcherSpecs.add(new GroupMatcherSpec());
+        matcherSpecs.add(new CallPointMatcherSpec());
         return matcherSpecs;
     }
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpConstant.java
@@ -18,6 +18,7 @@ public class HttpConstant {
     public static final String OKHTTP3 = "okhttp3";
     public static final String ASYNC_HTTP_CLIENT = "asyncHttpClient";
     public static final String getURI = "getURI";
+    public static final String CALL_POINT_KEY = "call-point";
 
     public static final Map<String, Method> methodMap = new HashMap<String, Method>();
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpEnhancer.java
@@ -22,6 +22,7 @@ import com.alibaba.chaosblade.exec.common.model.action.delay.BaseTimeoutExecutor
 import com.alibaba.chaosblade.exec.common.model.action.delay.TimeoutExecutor;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import com.alibaba.chaosblade.exec.plugin.http.model.CallPointMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,8 @@ public abstract class HttpEnhancer extends BeforeEnhancer {
         EnhancerModel enhancerModel = new EnhancerModel(classLoader, matcherModel);
         int timeout = getTimeout(object, methodArguments);
         postDoBeforeAdvice(enhancerModel);
+        StackTraceElement[] stackTrace = new NullPointerException().getStackTrace();
+        enhancerModel.addCustomMatcher(HttpConstant.CALL_POINT_KEY, stackTrace, CallPointMatcher.getInstance());
         enhancerModel.setTimeoutExecutor(createTimeoutExecutor(classLoader, timeout, className));
         return enhancerModel;
     }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/CallPointMatcher.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/CallPointMatcher.java
@@ -1,0 +1,58 @@
+package com.alibaba.chaosblade.exec.plugin.http.model;
+
+import com.alibaba.chaosblade.exec.common.aop.CustomMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class CallPointMatcher implements CustomMatcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CallPointMatcher.class);
+    private static final CallPointMatcher INSTANCE = new CallPointMatcher();
+
+    private CallPointMatcher() {}
+
+    public static CallPointMatcher getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean match(String commandValue, Object originValue) {
+        // match the class and method name who send the request.
+        try {
+            if (commandValue == null || commandValue.isEmpty()) {
+                LOGGER.debug("commandValue is null, match success, commandValue:{}", commandValue);
+                return true;
+            }
+            if (originValue == null) {
+                LOGGER.debug("originValue is null, match fail, commandValue:{}", commandValue);
+                return false;
+            }
+            StackTraceElement[] stackTrace = (StackTraceElement[])originValue;
+            if (stackTrace.length == 0) {
+                LOGGER.debug("stackTrace length is zero, match fail, commandValue:{}", commandValue);
+                return false;
+            }
+            for (StackTraceElement element : stackTrace) {
+                String callPoint = buildCallPoint(element);
+                if (commandValue.equalsIgnoreCase(callPoint)) {
+                    LOGGER.debug("call point equals, match success, commandValue:{}", commandValue);
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("match call point fail, commandValue:{}, originValue:{}", commandValue, originValue, e);
+        }
+        return false;
+    }
+
+    private String buildCallPoint(StackTraceElement element) {
+        return element.getClassName() + "|" + element.getMethodName();
+    }
+
+    @Override
+    public boolean regexMatch(String commandValue, Object originValue) {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/CallPointMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/CallPointMatcherSpec.java
@@ -1,0 +1,29 @@
+package com.alibaba.chaosblade.exec.plugin.http.model;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.http.HttpConstant;
+
+/**
+ * @author shizhi.zhu@qunar.com
+ */
+public class CallPointMatcherSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return HttpConstant.CALL_POINT_KEY;
+    }
+
+    @Override
+    public String getDesc() {
+        return "the class and method name who send the request";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/HttpModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/HttpModelSpec.java
@@ -64,6 +64,7 @@ public class HttpModelSpec extends FrameworkModelSpec {
         matcherSpecs.add(new Okhttp3MatcherSpec());
         matcherSpecs.add(new AsyncHttpClientMatcherSpec());
         matcherSpecs.add(new UriMatcherDefSpec());
+        matcherSpecs.add(new CallPointMatcherSpec());
         return matcherSpecs;
     }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
- **Support Dubbo/HTTP call point match.**
```
blade create http delay --time 500 --uri http://api.bservice.xxx.com/api/user/list --call-point com.xxx.service.AService|a1Method
```
When the request is sent from **AService.a1method**, the delay executor takes effect. When the request is sent from **AService.a2method**, the delay executor will not be triggered.


- **Fix Dubbo consumer generalization invoke methodname bug.**
```
dubbo matchers: {"matchers":{"appname":"test_provider","service":"com.test.provider.api.DubboTestService","version":"1.0.0","group":"test","methodname":"testDubbo","timeout":"3000"}}
```
The generalization call of Dubbo consumer is right in identifying the method name. 

### Does this pull request fix one issue?
Fixes #185 #186

