### PR TITLE
Support refresh flag for reloading the java agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BLADE_SRC_ROOT=`pwd`
 UNAME := $(shell uname)
 
 ifeq ($(BLADE_VERSION), )
-	BLADE_VERSION=1.2.0
+	BLADE_VERSION=1.3.0
 endif
 
 PLUGINS_PATH=plugins

--- a/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/pom.xml
+++ b/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-bootstrap</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.alibaba.jvm.sandbox</groupId>
             <artifactId>sandbox-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/src/main/java/com/alibaba/chaosblade/exec/bootstrap/jvmsandbox/SandboxModule.java
+++ b/chaosblade-exec-bootstrap/chaosblade-exec-bootstrap-jvmsandbox/src/main/java/com/alibaba/chaosblade/exec/bootstrap/jvmsandbox/SandboxModule.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * @author Changjun Xiao
  * @author hzyangshurui
  */
-@Information(id = "chaosblade", version = "1.2.0", author = "Changjun Xiao", isActiveOnLoad = false)
+@Information(id = "chaosblade", version = "1.3.0", author = "Changjun Xiao", isActiveOnLoad = false)
 public class SandboxModule implements Module, ModuleLifecycle, PluginLifecycleListener {
 
     private static Logger LOGGER = LoggerFactory.getLogger(SandboxModule.class);

--- a/chaosblade-exec-bootstrap/pom.xml
+++ b/chaosblade-exec-bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-jvm</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-common/pom.xml
+++ b/chaosblade-exec-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-jvm</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-druid/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-druid/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-elasticsearch/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hbase/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/dependency-reduced-pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>chaosblade-exec-plugin</artifactId>
     <groupId>com.alibaba.chaosblade</groupId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>chaosblade-exec-plugin-jvm</artifactId>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.alibaba.chaosblade</groupId>
       <artifactId>chaosblade-exec-common</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-lettuce/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-lettuce/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.alibaba.chaosblade</groupId>
             <artifactId>chaosblade-exec-common</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-mongodb/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-mongodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-mysql/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-mysql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-postgrelsql/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-postgrelsql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-rabbitmq/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-rabbitmq/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-redisson/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-redisson/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>chaosblade-exec-plugin</artifactId>
 		<groupId>com.alibaba.chaosblade</groupId>
-		<version>1.2.0</version>
+		<version>1.3.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-rocketmq/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-rocketmq/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-tars/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-tars/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>chaosblade-exec-plugin</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-plugin/pom.xml
+++ b/chaosblade-exec-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-jvm</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-service/pom.xml
+++ b/chaosblade-exec-service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>chaosblade-exec-jvm</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/ActionSpecBean.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/ActionSpecBean.java
@@ -47,6 +47,7 @@ public class ActionSpecBean {
         // add jvm process flag to identify the experiment java process
         this.flags.add(new FlagSpecBean(new ProcessFlagBean()));
         this.flags.add(new FlagSpecBean(new ProcessIdBean()));
+        this.flags.add(new FlagSpecBean(new RefreshFlagBean()));
         this.example = spec.getExample();
         this.programs = new String[] {"java"};
         this.categories = spec.getCategories();

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/RefreshFlagBean.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/RefreshFlagBean.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.service.build;
+
+import com.alibaba.chaosblade.exec.common.model.FlagSpec;
+
+/**
+ * @author Changjun Xiao
+ */
+public class RefreshFlagBean implements FlagSpec {
+
+    @Override
+    public String getName() {
+        return "refresh";
+    }
+
+    @Override
+    public String getDesc() {
+        return "Uninstall java agent and reload it";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return true;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/ModelParser.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/ModelParser.java
@@ -35,7 +35,7 @@ import com.alibaba.chaosblade.exec.common.util.StringUtil;
 public class ModelParser {
 
     public final static Set<String> assistantFlag = new HashSet<String>(Arrays.asList(
-        "target", "action", "process", "pid", "debug", "suid", "help", "pod", "uid"
+        "target", "action", "process", "pid", "debug", "suid", "help", "pod", "uid", "refresh", "blade-override"
     ));
 
     public static Model parseRequest(String target, Request request, ActionSpec actionSpec) {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.alibaba.chaosblade</groupId>
     <artifactId>chaosblade-exec-jvm</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <modules>
         <module>chaosblade-exec-bootstrap</module>
         <module>chaosblade-exec-common</module>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
If you use `create` command to execute java experiments, the java agent will be loaded by default, but you can't reload it when the java agent update. So provide the `refresh` flag to reload it.

### Does this pull request fix one issue?
chaosblade-io/chaosblade#524
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add `refresh` flag in java experiment.
2. Add the `refresh` judgement in blade command.

### Describe how to verify it
Re-execute `blade c jvm cpufullload --process tomcat --cpu-count 1` without `refresh` command, the chaosblade log is as follows:
![image](https://user-images.githubusercontent.com/3992234/124709946-aedada00-df2e-11eb-8ba2-44110586cf13.png)

Re-execute `blade c jvm cpufullload --process tomcat --cpu-count 1 --refresh`, the chaosblade log is as follows:
![image](https://user-images.githubusercontent.com/3992234/124710159-f8c3c000-df2e-11eb-8740-35617abf8d8c.png)



### Special notes for reviews
