### PR TITLE
feature: add javaHome flag in creating operation

### DIFF
--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/ActionSpecBean.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/ActionSpecBean.java
@@ -48,6 +48,7 @@ public class ActionSpecBean {
         this.flags.add(new FlagSpecBean(new ProcessFlagBean()));
         this.flags.add(new FlagSpecBean(new ProcessIdBean()));
         this.flags.add(new FlagSpecBean(new RefreshFlagBean()));
+        this.flags.add(new FlagSpecBean(new JavaHomeFlagBean()));
         this.example = spec.getExample();
         this.programs = new String[] {"java"};
         this.categories = spec.getCategories();

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/JavaHomeFlagBean.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/build/JavaHomeFlagBean.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.service.build;
+
+import com.alibaba.chaosblade.exec.common.model.FlagSpec;
+
+/**
+ * @author Changjun Xiao
+ */
+public class JavaHomeFlagBean implements FlagSpec {
+
+    @Override
+    public String getName() {
+        return "javaHome";
+    }
+
+    @Override
+    public String getDesc() {
+        return "Specify the JAVA_HOME variable to loading jre lib";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/ModelParser.java
+++ b/chaosblade-exec-service/src/main/java/com/alibaba/chaosblade/exec/service/handler/ModelParser.java
@@ -35,7 +35,8 @@ import com.alibaba.chaosblade.exec.common.util.StringUtil;
 public class ModelParser {
 
     public final static Set<String> assistantFlag = new HashSet<String>(Arrays.asList(
-        "target", "action", "process", "pid", "debug", "suid", "help", "pod", "uid", "refresh", "blade-override"
+        "target", "action", "process", "pid", "debug", "suid", "help", "pod", "uid", "refresh", "blade-override",
+        "javaHome"
     ));
 
     public static Model parseRequest(String target, Request request, ActionSpec actionSpec) {


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Specify the JAVA_HOME address through this parameter for loading the chaosblade java agent.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add `javaHome` flag.
2. Parse the flag in chaosblade cli.

### Describe how to verify it
Compile and test it.
```
blade c jvm cpufullload --javaHome /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home --process tomcat --refresh 
```

### Special notes for reviews
