### PR TITLE
feature: add business data match

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -53,6 +53,13 @@
                 <include>**/**</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>chaosblade-exec-spi/target/classes</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>**/**</include>
+            </includes>
+        </fileSet>
 
         <!-- plugins -->
         <fileSet>

--- a/chaosblade-exec-common/pom.xml
+++ b/chaosblade-exec-common/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.alibaba.chaosblade</groupId>
+            <artifactId>chaosblade-exec-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/BeforeEnhancer.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/BeforeEnhancer.java
@@ -44,11 +44,16 @@ public abstract class BeforeEnhancer implements Enhancer {
             return;
         }
         EnhancerModel model = doBeforeAdvice(classLoader, className, object, method, methodArguments);
+        model = addModelMatchers(classLoader, className, object, method, methodArguments, model, targetName);
         if (model == null) {
             return;
         }
         model.setTarget(targetName).setMethod(method).setObject(object).setMethodArguments(methodArguments);
         Injector.inject(model);
+    }
+
+    public EnhancerModel addModelMatchers(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments, EnhancerModel model, String targetName) throws Exception {
+        return model;
     }
 
     /**

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/matcher/busi/BusinessParamMatcher.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/aop/matcher/busi/BusinessParamMatcher.java
@@ -1,0 +1,41 @@
+package com.alibaba.chaosblade.exec.common.aop.matcher.busi;
+
+import com.alibaba.chaosblade.exec.common.aop.CustomMatcher;
+import com.alibaba.chaosblade.exec.common.util.BusinessParamUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author wufunc@gmail.com
+ */
+public class BusinessParamMatcher implements CustomMatcher {
+    private static final BusinessParamMatcher INSTANCE = new BusinessParamMatcher();
+
+    private BusinessParamMatcher() {
+    }
+
+    public static BusinessParamMatcher getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean match(String commandValue, Object originValue) {
+        Map<String, String> businessData = (Map<String, String>) originValue;
+        List<BusinessParamUtil.BusinessParam> businessParams = BusinessParamUtil.parseFromJsonStr(commandValue);
+        for (BusinessParamUtil.BusinessParam businessParam : businessParams) {
+            if (!businessData.containsKey(businessParam.getKey())) {
+                return false;
+            }
+            if (!businessData.get(businessParam.getKey()).equals(businessParam.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean regexMatch(String commandValue, Object originValue) {
+        return false;
+    }
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/DefaultSPIServiceManager.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/DefaultSPIServiceManager.java
@@ -1,0 +1,51 @@
+package com.alibaba.chaosblade.exec.common.center;
+
+
+import java.util.*;
+
+public class DefaultSPIServiceManager implements SPIServiceManager {
+    private static  Map<String, List<Object>> spiMap;
+
+    static {
+        spiMap = new HashMap<String, List<Object>>();
+    }
+
+    @Override
+    public void load() {
+
+    }
+    @Override
+    public List<Object> getServices(String className, ClassLoader classLoader) {
+        if (spiMap.containsKey(className)) {
+            return spiMap.get(className);
+        }
+        synchronized (this) {
+            if (spiMap.containsKey(className)) {
+                return spiMap.get(className);
+            }
+            List<Object> services = loadService(className, classLoader);
+            spiMap.put(className, services);
+            return services;
+        }
+    }
+
+    public List<Object> loadService(String className, ClassLoader classLoader) {
+        Class clazz;
+        try {
+            clazz = classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            return Collections.EMPTY_LIST;
+        }
+        ServiceLoader serviceLoader = ServiceLoader.load(clazz, classLoader);
+        List<Object> objects = new ArrayList<Object>();
+        for (Object object : serviceLoader) {
+            objects.add(object);
+        }
+        return objects;
+    }
+
+    @Override
+    public void unload() {
+        spiMap.clear();
+    }
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/ManagerFactory.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/ManagerFactory.java
@@ -34,6 +34,8 @@ public class ManagerFactory {
      */
     private static ListenerManager listenerManager = new DefaultListenerManager();
 
+    private static SPIServiceManager spiServiceManager = new DefaultSPIServiceManager();
+
     public static StatusManager getStatusManager() {
         return statusManager;
     }
@@ -46,10 +48,15 @@ public class ManagerFactory {
         return listenerManager;
     }
 
+    public static SPIServiceManager spiServiceManager() {
+        return spiServiceManager;
+    }
+
     public static void load() {
         modelSpecManager.load();
         listenerManager.load();
         statusManager.load();
+        spiServiceManager.load();
     }
 
     /**
@@ -59,5 +66,6 @@ public class ManagerFactory {
         statusManager.unload();
         modelSpecManager.unload();
         listenerManager.unload();
+        spiServiceManager.unload();
     }
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/SPIServiceManager.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/center/SPIServiceManager.java
@@ -1,0 +1,7 @@
+package com.alibaba.chaosblade.exec.common.center;
+
+import java.util.List;
+
+public interface SPIServiceManager extends ManagerService{
+    List<Object> getServices(String className, ClassLoader classLoader);
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
@@ -22,6 +22,10 @@ package com.alibaba.chaosblade.exec.common.constant;
 public interface ModelConstant {
     String JVM_TARGET = "jvm";
 
+    String HTTP_TARGET = "http";
+
+    String HTTP_URL_MATCHER_NAME = "uri";
+
     /**
      * The name of effect percent matcher
      */
@@ -36,4 +40,9 @@ public interface ModelConstant {
      * The flag of regex pattern
      */
     String REGEX_PATTERN_FLAG = "regex-pattern";
+
+    /**
+     * the flag of buisness params
+     */
+    String BUSINESS_PARAMS = "b-params";
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/context/ThreadLocalContext.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/context/ThreadLocalContext.java
@@ -1,22 +1,45 @@
 package com.alibaba.chaosblade.exec.common.context;
 
+import java.util.Map;
+
 /**
  * @author shizhi.zhu@qunar.com
  */
 public class ThreadLocalContext {
 
     private static ThreadLocalContext DEFAULT = new ThreadLocalContext();
-    private InheritableThreadLocal<Object> local = new InheritableThreadLocal<Object>();
+    private InheritableThreadLocal<Content> local = new InheritableThreadLocal<Content>();
 
     public static ThreadLocalContext getInstance() {
         return DEFAULT;
     }
 
-    public void set(Object value) {
+    public void set(Content value) {
         local.set(value);
     }
 
-    public Object get() {
+    public Content get() {
         return local.get();
+    }
+
+    public static class Content{
+        private  StackTraceElement[] stackTraceElements;
+        private Map<String, Map<String, String>> businessData;
+
+        public StackTraceElement[] getStackTraceElements() {
+            return stackTraceElements;
+        }
+
+        public void setStackTraceElements(StackTraceElement[] stackTraceElements) {
+            this.stackTraceElements = stackTraceElements;
+        }
+
+        public Map<String, Map<String, String>> getBusinessData() {
+            return businessData;
+        }
+
+        public void settValue(Map<String, Map<String, String>>  businessData) {
+            this.businessData = businessData;
+        }
     }
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
@@ -28,6 +28,7 @@ import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
 import com.alibaba.chaosblade.exec.common.model.action.returnv.UnsupportedReturnTypeException;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import com.alibaba.chaosblade.exec.common.util.ModelUtil;
 import com.alibaba.chaosblade.exec.common.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,8 +164,12 @@ public class Injector {
                         continue;
                     }
                 }
-
                 return false;
+            }
+            // business param match
+            if (keyName.equals(ModelConstant.BUSINESS_PARAMS)) {
+                Map<String, Map<String, String>> expMap = (Map<String, Map<String, String>>) value;
+                value = expMap.get(ModelUtil.getIdentifier(model));
             }
             // custom match
             if (keyName.endsWith(ModelConstant.REGEX_PATTERN_FLAG) ? customMatcher.regexMatch(String.valueOf(entry.getValue()), value) : customMatcher.match(String.valueOf(entry.getValue()), value)) {

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/BusinessParamsMatcherSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/BusinessParamsMatcherSpec.java
@@ -1,0 +1,42 @@
+package com.alibaba.chaosblade.exec.common.model.matcher;
+
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
+import com.alibaba.chaosblade.exec.common.util.BusinessParamUtil;
+
+import java.util.List;
+
+/**
+ * @author wufunc@gmail.com
+ */
+public class BusinessParamsMatcherSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return ModelConstant.BUSINESS_PARAMS;
+    }
+
+    @Override
+    public String getDesc() {
+        return "business parmas";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+
+    @Override
+    public PredicateResult predicate(MatcherModel matcherModel) {
+        String bParam = matcherModel.get(ModelConstant.BUSINESS_PARAMS);
+        List<BusinessParamUtil.BusinessParam> params = BusinessParamUtil.parseFromJsonStr(bParam);
+        if (params == null || params.isEmpty()) {
+            return PredicateResult.fail(getName() + " illegal json");
+        }
+        return PredicateResult.success();
+    }
+}

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/util/BusinessParamUtil.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/util/BusinessParamUtil.java
@@ -1,0 +1,167 @@
+package com.alibaba.chaosblade.exec.common.util;
+
+import com.alibaba.chaosblade.exec.common.center.ManagerFactory;
+import com.alibaba.chaosblade.exec.common.center.StatusMetric;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
+import com.alibaba.chaosblade.exec.common.model.Model;
+import com.alibaba.chaosblade.exec.spi.BusinessDataGetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * @author wufunc@gmail.com
+ */
+public class BusinessParamUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BusinessParamUtil.class);
+
+    private static Map<String, List<BusinessParam>> getAndParse(String target) throws Exception {
+        Map<String, List<BusinessParam>> paramsMap = new HashMap<String, List<BusinessParam>>();
+        List<StatusMetric> statusMetrics = ManagerFactory.getStatusManager().getExpByTarget(
+                target);
+        for (StatusMetric statusMetric : statusMetrics) {
+            Model model = statusMetric.getModel();
+            String flag = model.getMatcher().get(ModelConstant.BUSINESS_PARAMS);
+            List<BusinessParam> businessParams = parseFromJsonStr(flag);
+            paramsMap.put(ModelUtil.getIdentifier(model), businessParams);
+        }
+        return paramsMap;
+    }
+
+    public static List<BusinessParam> parseFromJsonStr(String str) {
+        try {
+            if (!StringUtil.isBlank(str)) {
+                return Arrays.asList(JsonUtil.reader().readValue(str, BusinessParam[].class));
+            }
+        } catch (Exception exp) {
+            LOGGER.warn("{} is not illegal json ", ModelConstant.BUSINESS_PARAMS);
+        }
+        return Collections.EMPTY_LIST;
+    }
+
+    public static Map<String, Map<String, String>> getAndParse(String target, BusinessDataGetter dataGetter) throws Exception {
+        Map<String, List<BusinessParam>> businessParams = getAndParse(target);
+        Map<String, Map<String, String>> result = new HashMap<String, Map<String, String>>();
+        for (Map.Entry<String, List<BusinessParam>> entry : businessParams.entrySet()) {
+            result.put(entry.getKey(), new HashMap<String, String>());
+            for (BusinessParam businessParam : entry.getValue()) {
+                String value = "";
+                if (businessParam.getMode().equals(mode.rpc.getValue())) {
+                    value = getValueFromRpc(businessParam, dataGetter);
+                } else {
+                    value = getValueFromSPI(businessParam, dataGetter);
+                }
+                if (!StringUtils.isEmpty(value)) {
+                    result.get(entry.getKey()).put(businessParam.getKey(), value);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String getValueFromSPI(BusinessParam businessParam, BusinessDataGetter dataGetter) {
+        List<Object> objects = ManagerFactory.spiServiceManager().getServices(BusinessDataGetter.class.getName(), Thread.currentThread().getContextClassLoader());
+        if (objects == null || objects.isEmpty()) {
+            return null;
+        }
+        for (Object object : objects) {
+            String tmpValue = null;
+            try {
+                tmpValue = ReflectUtil.invokeMethod(object, "get", new Object[]{businessParam.getKey()}, true);
+            } catch (Exception e) {
+                LOGGER.warn("get business value from spi class error,class :{}", object.getClass().getName(), e);
+            }
+            if (!StringUtils.isEmpty(tmpValue)) {
+                return tmpValue;
+            }
+        }
+        return null;
+    }
+
+    private static String getValueFromRpc(BusinessParam businessParam, BusinessDataGetter dataGetter) {
+        String value = "";
+        try {
+            if (businessParam.hasMultiLevelKey()) {
+                String json = dataGetter.get(businessParam.getFirstLevelKey());
+                if (StringUtils.isEmpty(json)) {
+                    return null;
+                }
+                JsonNode jsonNode = JsonUtil.reader().readTree(json);
+                JsonNode nodeResult = jsonNode.findValue(businessParam.getJsonPath());
+                if ((nodeResult != null)) {
+                    value = nodeResult.asText();
+                }
+            } else {
+                value = dataGetter.get(businessParam.getKey());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("get business data from rpc error", e);
+        }
+        return value;
+    }
+
+    public static class BusinessParam {
+        private String key;
+        private String value;
+        private String mode = BusinessParamUtil.mode.rpc.getValue();
+
+        public String getFirstLevelKey() {
+            if (hasMultiLevelKey()) {
+                return key.substring(0, key.indexOf("."));
+            } else {
+                return key;
+            }
+        }
+
+        public boolean hasMultiLevelKey() {
+            if (key.contains(".")) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        public String getJsonPath() {
+            return key.substring(key.indexOf(".") + 1, key.length());
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getMode() {
+            return mode;
+        }
+
+        public void setMode(String mode) {
+            this.mode = mode;
+        }
+    }
+
+    private enum mode {
+        spi("spi"), rpc("rpc");
+        private String value;
+
+        mode(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboEnhancer.java
@@ -22,8 +22,7 @@ import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
 import com.alibaba.chaosblade.exec.common.model.action.delay.TimeoutExecutor;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
-import com.alibaba.chaosblade.exec.common.util.JsonUtil;
-import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
+import com.alibaba.chaosblade.exec.common.util.*;
 import com.alibaba.chaosblade.exec.plugin.dubbo.model.DubboThreadPoolFullExecutor;
 
 import org.slf4j.Logger;
@@ -41,19 +40,22 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
     public static final String GET_SERVICE_KEY = "getServiceKey";
     public static final String GET_METHOD_NAME = "getMethodName";
     public static final String GET_ARGUMENTS = "getArguments";
+    public static final String GET_ATTACHMENTS = "getAttachments";
     public static final String GENERIC = "generic";
     public static final String SPLIT_TOKEN = ":";
     public static final String GROUP_SEP = "/";
     public static final String GET_INVOKER = "getInvoker";
     public static final String RECEIVED_METHOD = "received";
+
+
     public static final int INVALID_POS = -1;
     private static final Logger LOGGER = LoggerFactory.getLogger(DubboEnhancer.class);
 
     @Override
     public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object,
                                         Method method, Object[]
-                                            methodArguments)
-        throws Exception {
+                                                methodArguments)
+            throws Exception {
         if (method.getName().equals(RECEIVED_METHOD)) {
             // received method for thread pool experiment
             DubboThreadPoolFullExecutor.INSTANCE.setWrappedChannelHandler(object);
@@ -70,14 +72,13 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
             LOGGER.warn("Url is null, can not get necessary values.");
             return null;
         }
-        String appName = ReflectUtil.invokeMethod(url, GET_PARAMETER, new Object[] {APPLICATION_KEY}, false);
         String methodName = null;
-        String provideGeneric = ReflectUtil.invokeMethod(url, GET_PARAMETER, new Object[] {GENERIC}, false);
+        String provideGeneric = ReflectUtil.invokeMethod(url, GET_PARAMETER, new Object[]{GENERIC}, false);
         boolean consumerGeneric = isConsumerGeneric(object, invocation);
         if (Boolean.valueOf(provideGeneric) || consumerGeneric) {
             Object[] arguments = ReflectUtil.invokeMethod(invocation, GET_ARGUMENTS, new Object[0], false);
             if (arguments.length > 1 && arguments[0] instanceof String) {
-                methodName = (String)arguments[0];
+                methodName = (String) arguments[0];
             }
             LOGGER.debug("generic is true, methodName:{}", methodName);
         } else {
@@ -88,25 +89,23 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
             LOGGER.warn("methodName is null, can not get necessary values.");
             return null;
         }
-
         String[] serviceAndVersionGroup = getServiceNameWithVersionGroup(invocation, url);
 
         MatcherModel matcherModel = new MatcherModel();
+        String appName = ReflectUtil.invokeMethod(url, GET_PARAMETER, new Object[]{APPLICATION_KEY}, false);
         matcherModel.add(DubboConstant.APP_KEY, appName);
         matcherModel.add(DubboConstant.SERVICE_KEY, serviceAndVersionGroup[0]);
         matcherModel.add(DubboConstant.VERSION_KEY, serviceAndVersionGroup[1]);
         if (2 < serviceAndVersionGroup.length &&
-            null != serviceAndVersionGroup[2]) {
+                null != serviceAndVersionGroup[2]) {
             matcherModel.add(DubboConstant.GROUP_KEY, serviceAndVersionGroup[2]);
         }
         matcherModel.add(DubboConstant.METHOD_KEY, methodName);
         int timeout = getTimeout(methodName, object, invocation);
         matcherModel.add(DubboConstant.TIMEOUT_KEY, timeout + "");
-
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("dubbo matchers: {}", JsonUtil.writer().writeValueAsString(matcherModel));
         }
-
         EnhancerModel enhancerModel = new EnhancerModel(classLoader, matcherModel);
         enhancerModel.setTimeoutExecutor(createTimeoutExecutor(classLoader, timeout, className));
 
@@ -119,7 +118,7 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
         Class type = ReflectUtil.getSuperclassFieldValue(object, "type", false);
         String clazz = type.getName();
         return methodName.contains("$invoke") && (clazz.equalsIgnoreCase("org.apache.dubbo.rpc.service.GenericService")
-            || clazz.equalsIgnoreCase("com.alibaba.dubbo.rpc.service.GenericService"));
+                || clazz.equalsIgnoreCase("com.alibaba.dubbo.rpc.service.GenericService"));
     }
 
     protected abstract void postDoBeforeAdvice(EnhancerModel enhancerModel);
@@ -148,9 +147,9 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
 
             String[] serviceAndVersion = serviceKey.split(SPLIT_TOKEN);
             if (serviceAndVersion.length == 1) {
-                return new String[] {serviceAndVersion[0], DEFAULT_VERSION, group};
+                return new String[]{serviceAndVersion[0], DEFAULT_VERSION, group};
             }
-            return new String[] {serviceAndVersion[0], serviceAndVersion[1], group};
+            return new String[]{serviceAndVersion[0], serviceAndVersion[1], group};
         }
     }
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/DubboModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/model/DubboModelSpec.java
@@ -31,6 +31,7 @@ import com.alibaba.chaosblade.exec.common.model.action.exception.ThrowCustomExce
 import com.alibaba.chaosblade.exec.common.model.action.threadpool.ThreadPoolFullActionSpec;
 import com.alibaba.chaosblade.exec.common.model.handler.PreCreateInjectionModelHandler;
 import com.alibaba.chaosblade.exec.common.model.handler.PreDestroyInjectionModelHandler;
+import com.alibaba.chaosblade.exec.common.model.matcher.BusinessParamsMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
 import com.alibaba.chaosblade.exec.common.plugin.MethodNameMatcherSpec;
@@ -89,6 +90,7 @@ public class DubboModelSpec extends FrameworkModelSpec implements PreCreateInjec
         matcherSpecs.add(new MethodNameMatcherSpec());
         matcherSpecs.add(new GroupMatcherSpec());
         matcherSpecs.add(new CallPointMatcherSpec());
+        matcherSpecs.add(new BusinessParamsMatcherSpec());
         return matcherSpecs;
     }
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/HttpEnhancer.java
@@ -18,7 +18,10 @@ package com.alibaba.chaosblade.exec.plugin.http;
 
 import java.lang.reflect.Method;
 import java.net.SocketTimeoutException;
+import java.util.Map;
 
+import com.alibaba.chaosblade.exec.common.aop.matcher.busi.BusinessParamMatcher;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +65,21 @@ public abstract class HttpEnhancer extends BeforeEnhancer {
         return enhancerModel;
     }
 
+    @Override
+    public EnhancerModel addModelMatchers(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments, EnhancerModel model, String targetName) {
+        try {
+            Map<String, Map<String, String>> businessParams = getBusinessParams(object, methodArguments, targetName);
+            if (businessParams != null) {
+                model.addCustomMatcher(ModelConstant.BUSINESS_PARAMS, businessParams, BusinessParamMatcher.getInstance());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Getting business params  occurs exception,return null", e);
+        }
+        return model;
+    }
+
+    protected abstract Map<String, Map<String, String>> getBusinessParams(Object instance, Object[] methodArguments, String tagetName) throws Exception;
+
     protected boolean shouldAddCallPoint() {
         return FlagUtil.hasFlag("http", HttpConstant.CALL_POINT_KEY);
     }
@@ -72,6 +90,7 @@ public abstract class HttpEnhancer extends BeforeEnhancer {
      * @param instance
      * @return
      */
+
     protected abstract int getTimeout(Object instance, Object[] methodArguments);
 
     /**

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/asynchttpclient/AsyncHttpClientEnhancerWrapper.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/asynchttpclient/AsyncHttpClientEnhancerWrapper.java
@@ -25,12 +25,25 @@ public class AsyncHttpClientEnhancerWrapper extends BeforeEnhancer {
 
     @Override
     public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method,
-        Object[] methodArguments) throws Exception {
+                                        Object[] methodArguments) throws Exception {
         Enhancer enhancer = container.get(className, method.getName());
         if (enhancer != null) {
             if (enhancer instanceof BeforeEnhancer) {
-                BeforeEnhancer beforeEnhancer = (BeforeEnhancer)enhancer;
+                BeforeEnhancer beforeEnhancer = (BeforeEnhancer) enhancer;
                 return beforeEnhancer.doBeforeAdvice(classLoader, className, object, method, methodArguments);
+            }
+        }
+        LOGGER.debug("Can't find enhancer for:{}#{}", className, method.getName());
+        return null;
+    }
+
+    @Override
+    public EnhancerModel addModelMatchers(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments, EnhancerModel model, String targetName) throws Exception {
+        Enhancer enhancer = container.get(className, method.getName());
+        if (enhancer != null) {
+            if (enhancer instanceof BeforeEnhancer) {
+                BeforeEnhancer beforeEnhancer = (BeforeEnhancer) enhancer;
+                return beforeEnhancer.addModelMatchers(classLoader, className, object, method, methodArguments, model, targetName);
             }
         }
         LOGGER.debug("Can't find enhancer for:{}#{}", className, method.getName());

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/httpclient3/HttpClient3Enhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/httpclient3/HttpClient3Enhancer.java
@@ -1,13 +1,16 @@
 package com.alibaba.chaosblade.exec.plugin.http.httpclient3;
 
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.util.BusinessParamUtil;
 import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import com.alibaba.chaosblade.exec.plugin.http.HttpEnhancer;
 import com.alibaba.chaosblade.exec.plugin.http.UrlUtils;
+import com.alibaba.chaosblade.exec.spi.BusinessDataGetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import static com.alibaba.chaosblade.exec.plugin.http.HttpConstant.*;
 
@@ -22,10 +25,24 @@ public class HttpClient3Enhancer extends HttpEnhancer {
     private static final String GET_PARAMS = "getParams";
     private static final String GET_SOCKET_TIMEOUT = "getSoTimeout";
     private static final String GET_CONNECTION_TIMEOUT = "getConnectionTimeout";
+    private static final String GET_REQUEST_HEADER = "getRequestHeader";
+    private static final String GET_VALUE = "getValue";
 
     @Override
     protected void postDoBeforeAdvice(EnhancerModel enhancerModel) {
         enhancerModel.addMatcher(HTTPCLIENT3, "true");
+    }
+
+    @Override
+    protected Map<String, Map<String, String>> getBusinessParams(Object instance, final Object[] methodArguments, String targetName) throws Exception {
+        return BusinessParamUtil.getAndParse(targetName, new BusinessDataGetter() {
+            @Override
+            public String get(String key) throws Exception {
+                Object httpMethod = methodArguments[1];
+                Object header = ReflectUtil.invokeMethod(httpMethod, GET_REQUEST_HEADER, new Object[]{key}, false);
+                return (String) ReflectUtil.invokeMethod(header, GET_VALUE, new Object[0], false);
+            }
+        });
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/httpclient4/HttpClient4Enhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/httpclient4/HttpClient4Enhancer.java
@@ -1,13 +1,16 @@
 package com.alibaba.chaosblade.exec.plugin.http.httpclient4;
 
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.util.BusinessParamUtil;
 import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import com.alibaba.chaosblade.exec.plugin.http.HttpEnhancer;
 import com.alibaba.chaosblade.exec.plugin.http.UrlUtils;
+import com.alibaba.chaosblade.exec.spi.BusinessDataGetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import static com.alibaba.chaosblade.exec.plugin.http.HttpConstant.*;
 
@@ -25,15 +28,30 @@ public class HttpClient4Enhancer extends HttpEnhancer {
     private static final String REQUEST_GET_CONNECT_TIMEOUT = "getConnectTimeout";
     private static final String REQUEST_GET_SOCKET_TIMEOUT = "getSocketTimeout";
     private static final String GET_CONFIG = "getConfig";
+    private static final String GET_FIRST_HEADER = "getFirstHeader";
 
     private static final String CLIENT_GET_CONNECTION_TIMEOUT = "getConnectionTimeout";
     private static final String CLIENT_GET_SOCKET_TIMEOUT = "getSoTimeout";
+    private static final String HTTP_HEADER_GET_VALUE = "getValue";
     private static final String HTTP_CONNECTION_PARAMS = "org.apache.http.params.HttpConnectionParams";
 
 
     @Override
     protected void postDoBeforeAdvice(EnhancerModel enhancerModel) {
         enhancerModel.addMatcher(HTTPCLIENT4, "true");
+    }
+
+    @Override
+    protected Map<String, Map<String, String>> getBusinessParams(Object instance, final Object[] methodArguments, String targetName) throws Exception {
+
+        return BusinessParamUtil.getAndParse(targetName, new BusinessDataGetter() {
+            @Override
+            public String get(String key) throws Exception {
+                Object request = methodArguments[1];
+                Object header = ReflectUtil.invokeMethod(request, GET_FIRST_HEADER, new Object[]{key}, false);
+                return (String) ReflectUtil.invokeMethod(header, HTTP_HEADER_GET_VALUE, new Object[0], false);
+            }
+        });
     }
 
     @Override

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/HttpModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/model/HttpModelSpec.java
@@ -4,6 +4,7 @@ import com.alibaba.chaosblade.exec.common.model.FrameworkModelSpec;
 import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
 import com.alibaba.chaosblade.exec.common.model.action.delay.DelayActionSpec;
 import com.alibaba.chaosblade.exec.common.model.action.exception.ThrowCustomExceptionActionSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.BusinessParamsMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
 
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ public class HttpModelSpec extends FrameworkModelSpec {
         matcherSpecs.add(new AsyncHttpClientMatcherSpec());
         matcherSpecs.add(new UriMatcherDefSpec());
         matcherSpecs.add(new CallPointMatcherSpec());
+        matcherSpecs.add(new BusinessParamsMatcherSpec());
         return matcherSpecs;
     }
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/okhttp3/Okhttp3Enhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-http/src/main/java/com/alibaba/chaosblade/exec/plugin/http/okhttp3/Okhttp3Enhancer.java
@@ -1,11 +1,15 @@
 package com.alibaba.chaosblade.exec.plugin.http.okhttp3;
 
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.util.BusinessParamUtil;
 import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import com.alibaba.chaosblade.exec.plugin.http.HttpEnhancer;
 import com.alibaba.chaosblade.exec.plugin.http.UrlUtils;
+import com.alibaba.chaosblade.exec.spi.BusinessDataGetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 import static com.alibaba.chaosblade.exec.plugin.http.HttpConstant.DEFAULT_TIMEOUT;
 import static com.alibaba.chaosblade.exec.plugin.http.HttpConstant.OKHTTP3;
@@ -31,6 +35,18 @@ public class Okhttp3Enhancer extends HttpEnhancer {
         enhancerModel.addMatcher(OKHTTP3, "true");
     }
 
+    @Override
+    protected Map<String, Map<String, String>> getBusinessParams(final Object instance, Object[] methodArguments, String targetName) throws Exception {
+
+        return BusinessParamUtil.getAndParse(targetName, new BusinessDataGetter() {
+            @Override
+            public String get(String key) throws Exception {
+                Object request = ReflectUtil.invokeMethod(instance, "request", new Object[0], false);
+                return (String) ReflectUtil.invokeMethod(request, "header", new Object[]{key}, false);
+            }
+        });
+    }
+    @Override
     protected int getTimeout(Object instance, Object[] methodArguments) {
         try {
             Object client = ReflectUtil.getFieldValue(instance, "client", false);

--- a/chaosblade-exec-plugin/pom.xml
+++ b/chaosblade-exec-plugin/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>chaosblade-exec-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba.chaosblade</groupId>
+            <artifactId>chaosblade-exec-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/chaosblade-exec-spi/pom.xml
+++ b/chaosblade-exec-spi/pom.xml
@@ -19,13 +19,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>chaosblade-exec-plugin</artifactId>
+        <artifactId>chaosblade-exec-jvm</artifactId>
         <groupId>com.alibaba.chaosblade</groupId>
         <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>chaosblade-exec-plugin-dubbo</artifactId>
+    <artifactId>chaosblade-exec-spi</artifactId>
+
     <build>
         <plugins>
             <plugin>
@@ -38,14 +39,6 @@
             </plugin>
         </plugins>
     </build>
-    <dependencies>
-        <dependency>
-            <groupId>com.alibaba.chaosblade</groupId>
-            <artifactId>chaosblade-exec-spi</artifactId>
-            <version>1.4.0</version>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
 
 
 </project>

--- a/chaosblade-exec-spi/src/main/java/com/alibaba/chaosblade/exec/spi/BusinessDataGetter.java
+++ b/chaosblade-exec-spi/src/main/java/com/alibaba/chaosblade/exec/spi/BusinessDataGetter.java
@@ -1,0 +1,8 @@
+package com.alibaba.chaosblade.exec.spi;
+
+/**
+ * @author wufunc@gmail.com
+ */
+public interface BusinessDataGetter {
+    String get(String key) throws Exception;
+}

--- a/doc/zh-cn/design.md
+++ b/doc/zh-cn/design.md
@@ -132,7 +132,7 @@ public void beforeAdvice(String targetName,
 ./blade create servlet --requestpath=/topic delay --time=3000
 ````
 该命令下发后，触发SandboxModule @Http("/create")注解标记的方法，将事件分发给com.alibaba.chaosblade.exec.service.handler.CreateHandler处理
-在判断必要的uid、target、action、model参数后调用handleInjection，handleInjection通过状态管理器注册本次实验，如果插件类型是PreCreateInjectionModelHandler的类型，将预处理一些东西。同是如果Action类型是DirectlyInjectionAction，那么将直接进行故障能力注入，如jvm oom等，如果不是那么将加载插件。
+在判断必要的uid、target、action、model参数后调用handleInjection，handleInjection通过状态管理器注册本次实验，如果插件类型是PreCreateInjectionModelHandler的类型，将预处理一些东西。同时如果Action类型是DirectlyInjectionAction，那么将直接进行故障能力注入，如jvm oom等，如果不是那么将加载插件。
 
 #### ModelSpec
 - PreCreateInjectionModelHandler	预创建
@@ -323,7 +323,7 @@ public Response handle(Request request) {
 ````shell
 ./blade revoke 98e792c9a9a5dfea
 ````
-该命令下发后，触发SandboxModule unload()事件，同是插件卸载。
+该命令下发后，触发SandboxModule unload()事件，同时插件卸载。
 
 ```java
 public void onUnload() throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <packaging>pom</packaging>
     <version>1.4.0</version>
     <modules>
+        <module>chaosblade-exec-spi</module>
         <module>chaosblade-exec-bootstrap</module>
         <module>chaosblade-exec-common</module>
         <module>chaosblade-exec-plugin</module>


### PR DESCRIPTION
Signed-off-by: wufan <wufunc@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
        Provides the ability to match specific business data for injection by getting business data from rpc or implementing the specific spi interface.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
       Fixes #203
### Describe how you did it
         blade create dubbo throwCustomException --consumer --service=com.qunar.api --version=1.0.0  --b-parms='[{
	"key":"a",
	"value":"a_value",
         “mode”:"spi"
},
{
	"key":"b",
	"value":"b_value",
         “mode”:"spi"
}]’

        