### PR TITLE
feat(small):Added jedis plugin multi-version support

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/Jedis3orLessEnhancerStrategy.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/Jedis3orLessEnhancerStrategy.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jedis;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
+import static com.alibaba.chaosblade.exec.plugin.jedis.JedisEnhancer.CHARSET;
+
+/**
+ * @author guoping.yao <a href="mailto:bryan880901@qq.com">
+ * @author liuhq <a href="15669072513@163.com">
+ * final RedisOutputStream os, final byte[] command, final byte[]... args
+ */
+public class Jedis3orLessEnhancerStrategy implements JedisMultiVersionStrategy {
+    private  final Logger LOGGER = LoggerFactory.getLogger(Jedis3orLessEnhancerStrategy.class);
+
+    @Override
+    public EnhancerModel process(ClassLoader classLoader, Object[] methodArguments) throws Exception{
+        Object command = methodArguments[1];
+        Object args = methodArguments[2];
+        if (!args.getClass().isArray() || !(args instanceof byte[][])) {
+            return null;
+        }
+        String cmd;
+        List<String> sargs = new ArrayList<String>();
+        byte[][] bargs = (byte[][])args;
+
+        cmd = new String((byte[])command, CHARSET);
+        for (byte[] barg : bargs) {
+            sargs.add(new String(barg, CHARSET));
+        }
+
+        String key = null;
+        if (sargs.size() > 0) {
+            key = sargs.get(0);
+        }
+
+        MatcherModel matcherModel = new MatcherModel();
+        matcherModel.add(JedisConstant.COMMAND_TYPE_MATCHER_NAME, cmd.toLowerCase());
+        if (key != null) {
+            matcherModel.add(JedisConstant.KEY_MATCHER_NAME, key);
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("jedis matchers: {}", JsonUtil.writer().writeValueAsString(matcherModel));
+        }
+        return new EnhancerModel(classLoader, matcherModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/Jedis4EnhancerStrategy.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/Jedis4EnhancerStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jedis;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Iterator;
+import static com.alibaba.chaosblade.exec.plugin.jedis.JedisEnhancer.JEDIS_4_PARAMS_LENGTH;
+
+/**
+ * @author liuhq <a href="15669072513@163.com">
+ * final RedisOutputStream os, final CommandArguments
+ */
+public class Jedis4EnhancerStrategy  implements JedisMultiVersionStrategy {
+    private final Logger LOGGER = LoggerFactory.getLogger(Jedis4EnhancerStrategy.class);
+
+    @Override
+    public EnhancerModel process(ClassLoader classLoader, Object[] methodArguments) throws Exception{
+        Object command = methodArguments[1];
+        Iterator iterator = ((Iterable) command).iterator();
+        String[] cmdAndKeyArray = new String[2];
+        for (int i = 0; i < JEDIS_4_PARAMS_LENGTH; i++) {
+            Object obj = iterator.next();
+            Object cmdBytes = ReflectUtil.invokeMethod(obj, "getRaw", new Object[0], false);
+            if (cmdBytes.getClass().isArray() && (cmdBytes instanceof byte[])) {
+                cmdAndKeyArray[i] = new String((byte[]) cmdBytes);
+            }
+        }
+        MatcherModel matcherModel = new MatcherModel();
+        if (cmdAndKeyArray[0] != null) {
+            matcherModel.add(JedisConstant.COMMAND_TYPE_MATCHER_NAME, cmdAndKeyArray[0].toLowerCase());
+        }
+        if (cmdAndKeyArray[1] != null) {
+            matcherModel.add(JedisConstant.KEY_MATCHER_NAME, cmdAndKeyArray[1]);
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("jedis matchers: {}", JsonUtil.writer().writeValueAsString(matcherModel));
+        }
+        return new EnhancerModel(classLoader, matcherModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/JedisEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/JedisEnhancer.java
@@ -17,67 +17,48 @@
 package com.alibaba.chaosblade.exec.plugin.jedis;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
 import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
-import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
-import com.alibaba.chaosblade.exec.common.util.JsonUtil;
-
+import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * @author guoping.yao <a href="mailto:bryan880901@qq.com">
+ * @author liuhq <a href="15669072513@163.com">
+ *  modified for  compatible jedis 4.x
  */
 public class JedisEnhancer extends BeforeEnhancer {
-
-    public static final String CHARSET = "UTF-8";
     private static final Logger LOGGER = LoggerFactory.getLogger(JedisEnhancer.class);
 
+    protected static final String CHARSET = "UTF-8";
+    protected final static String JEDIS_4_PARAM_CLASSNAME = "redis.clients.jedis.CommandArguments";
+    protected final static Integer JEDIS_3_ORLESS_PARAMS_LENGTH = 3;
+    protected final static Integer JEDIS_4_PARAMS_LENGTH = 2;
+    protected final static Integer JEDIS_MIN_PARAMS_LENGTH = Math.min(JEDIS_4_PARAMS_LENGTH,JEDIS_3_ORLESS_PARAMS_LENGTH);
+
     /**
-     * final RedisOutputStream os, final byte[] command, final byte[]... args
+     * compatible jedis 4.x or 3.x or less
      */
     @Override
     public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object,
                                         Method method, Object[] methodArguments)
-        throws Exception {
-        if (methodArguments == null || methodArguments.length != 3) {
-            LOGGER.info("The necessary parameters is null or length is not equal 3, {}",
-                methodArguments != null ? methodArguments.length : null);
+            throws Exception {
+        JedisMultiVersionStrategy jedisMultiVersionStrategy;
+        if(methodArguments == null || methodArguments.length < JEDIS_MIN_PARAMS_LENGTH){
             return null;
         }
-        Object command = methodArguments[1];
-        if (!(command instanceof byte[])) {
+        Object mehtedArgument = methodArguments[1];
+        boolean isAssignFromJedis4 = ReflectUtil.isAssignableFrom(classLoader,mehtedArgument.getClass(), JEDIS_4_PARAM_CLASSNAME);
+        boolean isAssignFromJedis3 = mehtedArgument instanceof byte[];
+        if(methodArguments.length == JEDIS_3_ORLESS_PARAMS_LENGTH && isAssignFromJedis3){
+            jedisMultiVersionStrategy = new Jedis3orLessEnhancerStrategy();
+        }else if(methodArguments.length == JEDIS_4_PARAMS_LENGTH && isAssignFromJedis4){
+            jedisMultiVersionStrategy = new Jedis4EnhancerStrategy();
+        }else{
+            LOGGER.info("The necessary parameters is null or length is not equal 2 or 3, {}", methodArguments.length);
             return null;
         }
-
-        Object args = methodArguments[2];
-        if (!args.getClass().isArray() || !(args instanceof byte[][])) {
-            return null;
-        }
-        String cmd = new String((byte[])command, CHARSET);
-        List<String> sargs = new ArrayList<String>();
-
-        byte[][] bargs = (byte[][])args;
-        for (int i = 0; i < bargs.length; i++) {
-            sargs.add(new String(bargs[i], CHARSET));
-        }
-
-        String key = null;
-        if (sargs.size() > 0) {
-            key = sargs.get(0);
-        }
-
-        MatcherModel matcherModel = new MatcherModel();
-        matcherModel.add(JedisConstant.COMMAND_TYPE_MATCHER_NAME, cmd.toLowerCase());
-        if (key != null) {
-            matcherModel.add(JedisConstant.KEY_MATCHER_NAME, key);
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("jedis matchers: {}", JsonUtil.writer().writeValueAsString(matcherModel));
-        }
-        return new EnhancerModel(classLoader, matcherModel);
+        return jedisMultiVersionStrategy.process(classLoader,methodArguments);
     }
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/JedisMultiVersionStrategy.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jedis/src/main/java/com/alibaba/chaosblade/exec/plugin/jedis/JedisMultiVersionStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.plugin.jedis;
+
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+
+/**
+ * @author liuhq <a href="15669072513@163.com">
+ */
+public interface JedisMultiVersionStrategy {
+    /**
+     * jedis multi version strategy process
+     * @param classLoader classLoader
+     * @param methodArguments jedis method argument array
+     * @return EnhancerModel
+     * @throws Exception
+     */
+    EnhancerModel process(ClassLoader classLoader, Object[] methodArguments) throws Exception;
+}


### PR DESCRIPTION
  Added support for the jedis 4.0 version of the jedis plugin

Signed-off-by: liuhq <15669072513@163.com>


### Describe what this PR does / why we need it
Added support for the jedis 4.0 version of the jedis plugin

### Does this pull request fix one issue?
Fixes #225 


### Describe how you did it
By being compatible with the latest jedis 4.0 main class method :
redis.clients.jedis.Protocol.sendCommand 

### Describe how to verify it
By packaging exec-jvm and then verifying it on the Linux machine, the chaosblade command can be executed correctly


### Special notes for reviews
