### PR TITLE
dubbo obtain all  attachment parameters

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/DubboEnhancer.java
@@ -43,7 +43,7 @@ public abstract class DubboEnhancer extends BeforeEnhancer {
     public static final String GET_SERVICE_KEY = "getServiceKey";
     public static final String GET_METHOD_NAME = "getMethodName";
     public static final String GET_ARGUMENTS = "getArguments";
-    public static final String GET_ATTACHMENTS = "getAttachments";
+    public static final String GET_OBJECT_ATTACHMENTS = "getObjectAttachments";
     public static final String GENERIC = "generic";
     public static final String SPLIT_TOKEN = ":";
     public static final String GROUP_SEP = "/";

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/consumer/DubboConsumerEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/consumer/DubboConsumerEnhancer.java
@@ -117,11 +117,15 @@ public class DubboConsumerEnhancer extends DubboEnhancer {
         return BusinessParamUtil.getAndParse(DubboConstant.TARGET_NAME, new BusinessDataGetter() {
             @Override
             public String get(String key) throws Exception {
-                Map<String, String> attachments = ReflectUtil.invokeMethod(invocation, GET_ATTACHMENTS, new Object[0], false);
+                Map<String, Object> attachments = ReflectUtil.invokeMethod(invocation, GET_OBJECT_ATTACHMENTS, new Object[0], false);
                 if (attachments == null || attachments.isEmpty()) {
                     return null;
                 }
-                return attachments.get(key);
+                Object value = attachments.get(key);
+                if (value == null) {
+                    return null;
+                }
+                return value.toString();
             }
         });
     }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/provider/DubboProviderEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-dubbo/src/main/java/com/alibaba/chaosblade/exec/plugin/dubbo/provider/DubboProviderEnhancer.java
@@ -47,11 +47,15 @@ public class DubboProviderEnhancer extends DubboEnhancer {
         return BusinessParamUtil.getAndParse(DubboConstant.TARGET_NAME, new BusinessDataGetter() {
             @Override
             public String get(String key) throws Exception {
-                Map<String, String> attachments = ReflectUtil.invokeMethod(invocation, GET_ATTACHMENTS, new Object[0], false);
+                Map<String, Object> attachments = ReflectUtil.invokeMethod(invocation, GET_OBJECT_ATTACHMENTS, new Object[0], false);
                 if (attachments == null || attachments.isEmpty()) {
                     return null;
                 }
-                return attachments.get(key);
+                Object value = attachments.get(key);
+                if (value == null) {
+                    return null;
+                }
+                return value.toString();
             }
         });
     }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Currently, Dubbo can only get strings of attachments when using custom parameter matching. In fact need to get all the type parameters of the attachment.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
fix:https://github.com/chaosblade-io/chaosblade-exec-jvm/issues/213
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
