### PR TITLE
fix: create injection failed:null

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
@@ -32,6 +32,8 @@ import com.alibaba.chaosblade.exec.plugin.jvm.oom.JvmOomActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.script.model.JvmDynamicActionSpec;
 import com.alibaba.chaosblade.exec.plugin.jvm.thread.model.JvmThreadFullActionSpec;
 
+import java.util.Arrays;
+
 /**
  * Jvm model spec
  * <p>
@@ -92,7 +94,8 @@ public class JvmModelSpec extends MethodModelSpec implements PreCreateInjectionM
             try {
                 ((DirectlyInjectionAction) actionSpec).createInjection(uid, model);
             } catch (Exception e) {
-                throw new ExperimentException("create injection failed:" + e.getMessage());
+                e.printStackTrace();
+                throw new ExperimentException("create injection failed: " + Arrays.toString(e.getStackTrace()) + ", " + e, e);
             }
         } else {
             MethodPreInjectHandler.preHandleInjection(model);

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/JvmModelSpec.java
@@ -94,7 +94,6 @@ public class JvmModelSpec extends MethodModelSpec implements PreCreateInjectionM
             try {
                 ((DirectlyInjectionAction) actionSpec).createInjection(uid, model);
             } catch (Exception e) {
-                e.printStackTrace();
                 throw new ExperimentException("create injection failed: " + Arrays.toString(e.getStackTrace()) + ", " + e, e);
             }
         } else {

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/gc/FullGCExecutor.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/gc/FullGCExecutor.java
@@ -33,7 +33,7 @@ public class FullGCExecutor implements StoppableActionExecutor {
     @Override
     public synchronized void run(EnhancerModel enhancerModel) throws Exception {
         if (started.compareAndSet(false, true)) {
-            final int interval = ConfigUtil.getActionFlag(enhancerModel, JvmConstant.FLAG_FULL_GC_INTERVAL, 0);
+            final int interval = ConfigUtil.getActionFlag(enhancerModel, JvmConstant.FLAG_FULL_GC_INTERVAL, 1);
             final int totalCount = ConfigUtil.getActionFlag(enhancerModel, JvmConstant.FLAG_FULL_GC_TOTAL_COUNT, 0);
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
                 @Override
@@ -54,7 +54,7 @@ public class FullGCExecutor implements StoppableActionExecutor {
                         LOGGER.error("do gcClassHistogram error", e);
                     }
                 }
-            }, 0, interval, TimeUnit.MILLISECONDS);
+            }, 0, interval <= 0 ? 1 : interval, TimeUnit.MILLISECONDS);
         } else {
             LOGGER.warn("another executor is running now");
         }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
![image](https://user-images.githubusercontent.com/20470818/160228433-d4f1481f-5acf-4791-93a3-ed886eaabd6c.png)
![image](https://user-images.githubusercontent.com/20470818/160228444-4d44f033-3a43-404b-adde-481105c699aa.png)

When we inject a jvm full-gc fault, it is always failed first time.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

After I has optimized the return info with execption stack trace, I found it was a java.lang.IllegalArgumentException from ScheduledThreadPoolExecutor.scheduleAtFixedRate because of the interval equal 0.
![image](https://user-images.githubusercontent.com/20470818/160228587-d54c2b6a-92aa-4f94-832a-651c62af5fdc.png)

So, I fixed it by check interval, and use default and minimal value is 1.

Signed-off-by: NigelWu95 <bingheng.wbh@antgroup.com>

### Describe how to verify it


### Special notes for reviews
