### PR TITLE
spring security plugin

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>chaosblade-exec-plugin</artifactId>
+        <groupId>com.alibaba.chaosblade</groupId>
+        <version>1.7.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>chaosblade-exec-plugin-security</artifactId>
+
+
+</project>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityConstant.java
@@ -1,0 +1,14 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityConstant {
+
+    public static final String PLUGIN_NAME = "security";
+
+    public static final String PARAM_USERNAME = "username";
+
+    public static final String CLASS_UserDetailsService = "org.springframework.security.core.userdetails.UserDetailsService";
+    public static final String METHOD_UserDetailsService$loadUserByUsername = "loadUserByUsername";
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityEnhancer.java
@@ -1,0 +1,34 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityEnhancer extends BeforeEnhancer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityEnhancer.class);
+
+    @Override
+    public EnhancerModel doBeforeAdvice(ClassLoader classLoader,
+                                        String className,
+                                        Object object,
+                                        Method method,
+                                        Object[] methodArguments) throws Exception {
+        if (methodArguments.length < 1) {
+            LOGGER.warn("argument's length less than 1, className:{}, methodName:{}", className, method.getName());
+            return null;
+        }
+        Object username = methodArguments[0];
+
+        MatcherModel matcherModel = new MatcherModel();
+        matcherModel.add(SecurityConstant.PARAM_USERNAME, username);
+        return new EnhancerModel(classLoader, matcherModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityMatcherSpec.java
@@ -1,0 +1,29 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityMatcherSpec extends BasePredicateMatcherSpec {
+
+    @Override
+    public String getName() {
+        return SecurityConstant.PARAM_USERNAME;
+    }
+
+    @Override
+    public String getDesc() {
+        return "login username";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return true;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityModelSpec.java
@@ -1,0 +1,58 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+import com.alibaba.chaosblade.exec.common.model.FrameworkModelSpec;
+import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.delay.DelayActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.exception.ThrowCustomExceptionActionSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityModelSpec extends FrameworkModelSpec {
+
+    public SecurityModelSpec() {
+        addActionExample();
+    }
+
+    private void addActionExample() {
+        List<ActionSpec> actions = getActions();
+        for (ActionSpec action : actions) {
+            if (action instanceof DelayActionSpec) {
+                action.setLongDesc("SpringSecurity delay experiment");
+                action.setExample("# Do a delay 2s experiment for SpringSecurity login operation\n"
+                        + "blade create security delay --username admin --time 2000\n\n");
+            }
+            if (action instanceof ThrowCustomExceptionActionSpec) {
+                action.setLongDesc("SpringSecurity throws customer exception experiment");
+                action.setExample("# Do a throws customer exception experiment for SpringSecurity login\n" +
+                        "blade create security throwCustomException --exception java.lang.Exception --username admin");
+            }
+        }
+    }
+
+    @Override
+    protected List<MatcherSpec> createNewMatcherSpecs() {
+        ArrayList<MatcherSpec> matcherSpecs = new ArrayList<MatcherSpec>();
+        matcherSpecs.add(new SecurityMatcherSpec());
+        return matcherSpecs;
+    }
+
+    @Override
+    public String getTarget() {
+        return SecurityConstant.PLUGIN_NAME;
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "SpringSecurity login experiment";
+    }
+
+    @Override
+    public String getLongDesc() {
+        return "SpringSecurity login experiment contains delay and exception by command and so on";
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityPlugin.java
@@ -1,0 +1,32 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+import com.alibaba.chaosblade.exec.common.aop.Enhancer;
+import com.alibaba.chaosblade.exec.common.aop.Plugin;
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.common.model.ModelSpec;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityPlugin implements Plugin {
+
+    @Override
+    public String getName() {
+        return SecurityConstant.PLUGIN_NAME;
+    }
+
+    @Override
+    public ModelSpec getModelSpec() {
+        return new SecurityModelSpec();
+    }
+
+    @Override
+    public PointCut getPointCut() {
+        return new SecurityPointCut();
+    }
+
+    @Override
+    public Enhancer getEnhancer() {
+        return new SecurityEnhancer();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/java/com/alibaba/chaosblade/exec/plugin/security/SecurityPointCut.java
@@ -1,0 +1,23 @@
+package com.alibaba.chaosblade.exec.plugin.security;
+
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.ClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.InterfaceClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.NameMethodMatcher;
+
+/**
+ * @author liubin@njzfit.cn
+ */
+public class SecurityPointCut implements PointCut {
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return new InterfaceClassMatcher(SecurityConstant.CLASS_UserDetailsService);
+    }
+
+    @Override
+    public MethodMatcher getMethodMatcher() {
+        return new NameMethodMatcher(SecurityConstant.METHOD_UserDetailsService$loadUserByUsername);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-security/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2019 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.chaosblade.exec.plugin.security.SecurityPlugin

--- a/chaosblade-exec-plugin/pom.xml
+++ b/chaosblade-exec-plugin/pom.xml
@@ -50,6 +50,7 @@
         <module>chaosblade-exec-plugin-clickhouse</module>
         <module>chaosblade-exec-plugin-zookeeper</module>
         <module>chaosblade-exec-plugin-feign</module>
+        <module>chaosblade-exec-plugin-security</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
### Describe what this PR does / why we need it

一个 SpringSecurity 的故障注入插件

如果使用 SpringSecurity 框架，可以对用户登录流程进行故障注入

### Does this pull request fix one issue?

NONE

### Describe how you did it

内部对 UserDetailsService$loadUserByUsername(String username) 方法做切面，可对指定用户进行延迟登录或抛异常等操作

如果对 AuthenticationManager$authenticate(Authentication authentication) 做切面会多次触发

### Describe how to verify it

创建 SpringBoot 项目，使用 SpringSecurity 框架，进行认证流程配置（按框架默认配置或自定义配置）

注入后用指定用户登录，可看到延迟或异常

### Special notes for reviews

NONE
