### PR TITLE
fix: unable to access java.lang in JDK 11 version

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaCodeScriptEngine.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/src/main/java/com/alibaba/chaosblade/exec/plugin/jvm/script/java/JavaCodeScriptEngine.java
@@ -366,7 +366,9 @@ public class JavaCodeScriptEngine implements ScriptEngine {
         @Override
         public Iterable<JavaFileObject> list(Location location, String packageName, Set<Kind> kinds, boolean recurse)
             throws IOException {
-            if (location == StandardLocation.PLATFORM_CLASS_PATH) {
+            if (location.getName().contains("SYSTEM_MODULES") && location.getName().contains("java.base")){
+                return super.list(location, packageName, kinds, recurse);
+            } else if (location == StandardLocation.PLATFORM_CLASS_PATH) {
                 return super.list(location, packageName, kinds, recurse);
             } else if (location == StandardLocation.CLASS_PATH && kinds.contains(JavaFileObject.Kind.CLASS)) {
                 if (packageName.startsWith("java")) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:

-->

### Describe what this PR does / why we need it
I fixed a bug, please see the issue #299 

### Does this pull request fix one issue?
please see the issue #299 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
I added a new way of logging so that the program can display the real error on the production environment.
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/23691253/218224206-9d20351a-a119-471a-9508-c01ad7ef2a9e.png">

I was able to reproduce the error locally using the following code
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/23691253/218224300-efbf8d2d-572f-4819-a49d-c98372db7125.png">


### Describe how to verify it
```java
public static void main(String[] args) {
        String content = "package com.taobao.csp.monkeyking.script.java.source;\n" +
                "import java.util.Map;\n" +
                "public class CornApplication {\n" +
                "    public Object run(Map<String, Object> params) {\n" +
                "        return \"agents\";" +
                "}\n" +
                "}";
        Script script = new Script("1", null, null, content, null);
        JavaCodeScriptEngine engine = new JavaCodeScriptEngine();
        Object compile = engine.compile(script, CompileFailedTest.class.getClassLoader(), null);
    }