### PR TITLE
fix: set maven-assembly-plugin version 2.5.5 to support assembly:asse…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
                 <inherited>false</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <!-- assembly:assembly in Makefile is not supported since 2.6 -->
+                <version>2.5.5</version>
                 <configuration>
                     <finalName>chaosblade-java-agent</finalName>
                     <descriptors>


### PR DESCRIPTION
…mbly

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
If the plugin in pom.xml does not specify a version, it seems to get the latest available version.
However, the plugin maven-assembly-plugin version 2.6 and later no longer supports the "mvn clean assembly:assembly -Dmaven.test.skip=true -U" command used in the Makefile, which will cause the build to fail.

pom.xml中插件如果未指定版本，似乎会获取最新的可用版本。
但是插件maven-assembly-plugin在2.6及之后的版本不再支持Makefile中使用的"mvn clean assembly:assembly -Dmaven.test.skip=true -U"命令，这将导致构建失败。

### Does this pull request fix one issue?
Fixes #317.
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
In the pom.xml file, explicitly set the plugin version to the last version that supports the build commands in the Makefile.

在pom.xml文件中，明确设置插件版本为支持Makefile中构建命令的最后一个版本2.5.5。

### Describe how to verify it
"make" again and finally BUILD SUCCESS.

使用make命令构建，最终构建成功。

### Special notes for reviews
I'm newbie to Java so not too sure about the following. 
"mvn clean assembly:assembly -Dmaven.test.skip=true -U" used "-U". It seems that Maven should always get the latest version of the plugin from the central repository (or other configured remote repository )?
Maybe the plugin version in the remote repository you configured is a fixed old version?

我是Java方面的新手，所以不太确定以下内容。
"mvn clean assembly:assembly -Dmaven.test.skip=true -U"使用了"-U"，似乎Maven应该总是从中央仓库（或其他配置的远程仓库）获取最新版本的插件？
可能你们配置的远程仓库中的插件版本是固定的旧版本？