### PR TITLE
feat: new plugin for HDFS experiments

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>chaosblade-exec-plugin</artifactId>
+        <groupId>com.alibaba.chaosblade</groupId>
+        <version>1.7.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>chaosblade-exec-plugin-hdfs</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.11.0.GA</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/pom.xml
@@ -28,12 +28,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.11.0.GA</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.common;
 
 public class HdfsConstant {

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
@@ -1,0 +1,11 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.common;
+
+public class HdfsConstant {
+    public static final String TARGET_NAME = "hdfs";
+
+    public static final String PLUGIN_RESTFUL_HTTPFS_NAME = "restful_httpfs";
+    public static final String PLUGIN_RESTFUL_WEBHDFS_NAME = "restful_webhdfs";
+
+    public static final String FLAG_COMMON_FILE = "file";
+    public static final String FLAG_RESTFUL_OPERATION = "op";
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsConstant.java
@@ -8,4 +8,6 @@ public class HdfsConstant {
 
     public static final String FLAG_COMMON_FILE = "file";
     public static final String FLAG_RESTFUL_OPERATION = "op";
+
+    public static final String HDFS_ROOT_PATH = "/";
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.common;
 
 import com.alibaba.chaosblade.exec.common.model.FrameworkModelSpec;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
@@ -1,0 +1,54 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.common;
+
+import com.alibaba.chaosblade.exec.common.model.FrameworkModelSpec;
+import com.alibaba.chaosblade.exec.common.model.action.ActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.delay.DelayActionSpec;
+import com.alibaba.chaosblade.exec.common.model.action.exception.ThrowCustomExceptionActionSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.flag.HdfsFileMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.hdfs.restful.flag.HdfsRestfulOperationMatcherSpec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HdfsModelSpec extends FrameworkModelSpec {
+    public HdfsModelSpec() {
+        List<ActionSpec> actionSpecList = getActions();
+        for (ActionSpec actionSpec : actionSpecList) {
+            if (actionSpec instanceof DelayActionSpec) {
+                actionSpec.setLongDesc("Conduct delay experiment on HDFS file operations.");
+                actionSpec.setExample("# Perform a delay experiment for HDFS client.\n" +
+                        "EXAMPLE: blade create hdfs delay --time 1000 [--file example/demo.tmp] [--op open|getfilestatus|create|...]");
+            }
+            if (actionSpec instanceof ThrowCustomExceptionActionSpec) {
+                actionSpec.setLongDesc("Conduct throwing custom exception experiment on HDFS file operations.");
+                actionSpec.setExample("# Perform a throwing custom exception experiment for HDFS client.\n" +
+                        "EXAMPLE: blade create hdfs throwCustomException --exception java.lang.Exception [--file example/demo.tmp] [--op open|getfilestatus|create|...]");
+            }
+        }
+    }
+
+    @Override
+    protected List<MatcherSpec> createNewMatcherSpecs() {
+        ArrayList<MatcherSpec> matcherSpecList = new ArrayList<MatcherSpec>();
+        matcherSpecList.add(new HdfsFileMatcherSpec());
+        matcherSpecList.add(new HdfsRestfulOperationMatcherSpec());
+        return matcherSpecList;
+    }
+
+    @Override
+    public String getTarget() {
+        return HdfsConstant.TARGET_NAME;
+    }
+
+    @Override
+    public String getShortDesc() {
+        return "HDFS Chaos Experiment Plugin.";
+    }
+
+    @Override
+    public String getLongDesc() {
+        return "A ChaosBlade plugin to conduct chaos experiments on HDFS, which provides several kinds of chaos injection, " +
+                "such as making delay of response, throwing custom exception, blocking file operations etc.";
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsModelSpec.java
@@ -30,7 +30,7 @@ public class HdfsModelSpec extends FrameworkModelSpec {
 
     @Override
     protected List<MatcherSpec> createNewMatcherSpecs() {
-        ArrayList<MatcherSpec> matcherSpecList = new ArrayList<MatcherSpec>();
+        ArrayList<MatcherSpec> matcherSpecList = new ArrayList<>();
         matcherSpecList.add(new HdfsFileMatcherSpec());
         matcherSpecList.add(new HdfsRestfulOperationMatcherSpec());
         return matcherSpecList;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsPlugin.java
@@ -1,0 +1,11 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.common;
+
+import com.alibaba.chaosblade.exec.common.aop.Plugin;
+import com.alibaba.chaosblade.exec.common.model.ModelSpec;
+
+public abstract class HdfsPlugin implements Plugin {
+    @Override
+    public ModelSpec getModelSpec() {
+        return new HdfsModelSpec();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/HdfsPlugin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.common;
 
 import com.alibaba.chaosblade.exec.common.aop.Plugin;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/flag/HdfsFileMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/flag/HdfsFileMatcherSpec.java
@@ -1,0 +1,26 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.common.flag;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+
+public class HdfsFileMatcherSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return HdfsConstant.FLAG_COMMON_FILE;
+    }
+
+    @Override
+    public String getDesc() {
+        return "The target HDFS file path.";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/flag/HdfsFileMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/common/flag/HdfsFileMatcherSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.common.flag;
 
 import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/flag/HdfsRestfulOperationMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/flag/HdfsRestfulOperationMatcherSpec.java
@@ -1,0 +1,26 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.flag;
+
+import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+
+public class HdfsRestfulOperationMatcherSpec extends BasePredicateMatcherSpec {
+    @Override
+    public String getName() {
+        return HdfsConstant.FLAG_RESTFUL_OPERATION;
+    }
+
+    @Override
+    public String getDesc() {
+        return "Restful operation executed on remote HDFS file.";
+    }
+
+    @Override
+    public boolean noArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean required() {
+        return false;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/flag/HdfsRestfulOperationMatcherSpec.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/flag/HdfsRestfulOperationMatcherSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.flag;
 
 import com.alibaba.chaosblade.exec.common.model.matcher.BasePredicateMatcherSpec;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
 
 import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
@@ -1,0 +1,46 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
+
+import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import com.alibaba.chaosblade.exec.common.util.StringUtils;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+public class HdfsHttpFSEnhancer extends BeforeEnhancer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HdfsHttpFSEnhancer.class);
+
+    @Override
+    public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method,
+                                        Object[] methodArguments) throws Exception {
+        MatcherModel matcherModel = new MatcherModel();
+        if (HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_GET.equals(method.getName())
+            || HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_DELETE.equals(method.getName())) {
+            if (StringUtils.isNotBlank(String.valueOf(methodArguments[0]))) {
+                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, String.valueOf(methodArguments[0]));
+            }
+            if (methodArguments[1] != null && StringUtils.isNotBlank(String.valueOf(methodArguments[1]))) {
+                matcherModel.add(HdfsConstant.FLAG_RESTFUL_OPERATION, String.valueOf(methodArguments[1]).toLowerCase());
+            }
+        }
+        if (HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_PUT.equals(method.getName())
+            || HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_POST.equals(method.getName())) {
+            if (StringUtils.isNotBlank(String.valueOf(methodArguments[2]))) {
+                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, String.valueOf(methodArguments[2]));
+            }
+            if (methodArguments[1] != null && StringUtils.isNotBlank(String.valueOf(methodArguments[3]))) {
+                matcherModel.add(HdfsConstant.FLAG_RESTFUL_OPERATION, String.valueOf(methodArguments[3]).toLowerCase());
+            }
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{} matchers: {}", getClass().getName(), JsonUtil.writer().writeValueAsString(matcherModel));
+        }
+
+        return new EnhancerModel(classLoader, matcherModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSEnhancer.java
@@ -21,7 +21,7 @@ public class HdfsHttpFSEnhancer extends BeforeEnhancer {
         if (HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_GET.equals(method.getName())
             || HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_DELETE.equals(method.getName())) {
             if (StringUtils.isNotBlank(String.valueOf(methodArguments[0]))) {
-                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, String.valueOf(methodArguments[0]));
+                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, HdfsConstant.HDFS_ROOT_PATH + methodArguments[0]);
             }
             if (methodArguments[1] != null && StringUtils.isNotBlank(String.valueOf(methodArguments[1]))) {
                 matcherModel.add(HdfsConstant.FLAG_RESTFUL_OPERATION, String.valueOf(methodArguments[1]).toLowerCase());
@@ -30,7 +30,7 @@ public class HdfsHttpFSEnhancer extends BeforeEnhancer {
         if (HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_PUT.equals(method.getName())
             || HdfsHttpFSPointCut.METHOD_HDFS_HTTPFS_POST.equals(method.getName())) {
             if (StringUtils.isNotBlank(String.valueOf(methodArguments[2]))) {
-                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, String.valueOf(methodArguments[2]));
+                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, HdfsConstant.HDFS_ROOT_PATH + methodArguments[2]);
             }
             if (methodArguments[1] != null && StringUtils.isNotBlank(String.valueOf(methodArguments[3]))) {
                 matcherModel.add(HdfsConstant.FLAG_RESTFUL_OPERATION, String.valueOf(methodArguments[3]).toLowerCase());

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPlugin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
 
 import com.alibaba.chaosblade.exec.common.aop.Enhancer;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPlugin.java
@@ -1,0 +1,23 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
+
+import com.alibaba.chaosblade.exec.common.aop.Enhancer;
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsPlugin;
+
+public class HdfsHttpFSPlugin extends HdfsPlugin {
+    @Override
+    public String getName() {
+        return HdfsConstant.PLUGIN_RESTFUL_HTTPFS_NAME;
+    }
+
+    @Override
+    public PointCut getPointCut() {
+        return new HdfsHttpFSPointCut();
+    }
+
+    @Override
+    public Enhancer getEnhancer() {
+        return new HdfsHttpFSEnhancer();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPointCut.java
@@ -1,0 +1,31 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
+
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.ClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.NameClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.NameMethodMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.OrMethodMatcher;
+
+public class HdfsHttpFSPointCut implements PointCut {
+    private static final String CLASS_HDFS_HTTPFS_SERVER = "org.apache.hadoop.fs.http.server.HttpFSServer";
+    public static final String METHOD_HDFS_HTTPFS_GET = "get";
+    public static final String METHOD_HDFS_HTTPFS_PUT = "put";
+    public static final String METHOD_HDFS_HTTPFS_POST = "post";
+    public static final String METHOD_HDFS_HTTPFS_DELETE = "delete";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return new NameClassMatcher(CLASS_HDFS_HTTPFS_SERVER);
+    }
+
+    @Override
+    public MethodMatcher getMethodMatcher() {
+        OrMethodMatcher orMethodMatcher = new OrMethodMatcher();
+        orMethodMatcher.or(new NameMethodMatcher(METHOD_HDFS_HTTPFS_GET))
+                .or(new NameMethodMatcher(METHOD_HDFS_HTTPFS_PUT))
+                .or(new NameMethodMatcher(METHOD_HDFS_HTTPFS_POST))
+                .or(new NameMethodMatcher(METHOD_HDFS_HTTPFS_DELETE));
+        return orMethodMatcher;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/httpfs/HdfsHttpFSPointCut.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs;
 
 import com.alibaba.chaosblade.exec.common.aop.PointCut;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
 
 import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
@@ -20,7 +36,7 @@ public class HdfsWebHdfsEnhancer extends BeforeEnhancer {
                                         Object[] methodArguments) throws Exception {
         MatcherModel matcherModel = new MatcherModel();
         if (methodArguments[4] != null) {
-            String filePath = ReflectUtil.invokeMethod(methodArguments[4], "getAbsolutePath");
+            String filePath = String.valueOf(methodArguments[4]);
             if (StringUtils.isNotBlank(filePath)) {
                 matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, filePath.trim());
             }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
@@ -1,0 +1,44 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
+
+import com.alibaba.chaosblade.exec.common.aop.BeforeEnhancer;
+import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
+import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
+import com.alibaba.chaosblade.exec.common.util.JsonUtil;
+import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
+import com.alibaba.chaosblade.exec.common.util.StringUtils;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+public class HdfsWebHdfsEnhancer extends BeforeEnhancer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HdfsWebHdfsEnhancer.class);
+
+    @Override
+    public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method,
+                                        Object[] methodArguments) throws Exception {
+        MatcherModel matcherModel = new MatcherModel();
+        if (methodArguments[4] != null) {
+            String filePath = ReflectUtil.invokeMethod(methodArguments[4], "getValue");
+            if (StringUtils.isNotBlank(filePath)) {
+                matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, filePath.trim());
+            }
+        }
+        if (methodArguments[5] != null) {
+            Object operationParam = ReflectUtil.invokeMethod(methodArguments[5], "getValue");
+            if (operationParam != null) {
+                String operation = ReflectUtil.invokeMethod(operationParam, "name");
+                if (StringUtils.isNotBlank(operation)) {
+                    matcherModel.add(HdfsConstant.FLAG_RESTFUL_OPERATION, operation.trim().toLowerCase());
+                }
+            }
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{} matchers: {}", getClass().getName(), JsonUtil.writer().writeValueAsString(matcherModel));
+        }
+
+        return new EnhancerModel(classLoader, matcherModel);
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsEnhancer.java
@@ -20,7 +20,7 @@ public class HdfsWebHdfsEnhancer extends BeforeEnhancer {
                                         Object[] methodArguments) throws Exception {
         MatcherModel matcherModel = new MatcherModel();
         if (methodArguments[4] != null) {
-            String filePath = ReflectUtil.invokeMethod(methodArguments[4], "getValue");
+            String filePath = ReflectUtil.invokeMethod(methodArguments[4], "getAbsolutePath");
             if (StringUtils.isNotBlank(filePath)) {
                 matcherModel.add(HdfsConstant.FLAG_COMMON_FILE, filePath.trim());
             }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPlugin.java
@@ -1,0 +1,23 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
+
+import com.alibaba.chaosblade.exec.common.aop.Enhancer;
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsConstant;
+import com.alibaba.chaosblade.exec.plugin.hdfs.common.HdfsPlugin;
+
+public class HdfsWebHdfsPlugin extends HdfsPlugin{
+    @Override
+    public String getName() {
+        return HdfsConstant.PLUGIN_RESTFUL_WEBHDFS_NAME;
+    }
+
+    @Override
+    public PointCut getPointCut() {
+        return new HdfsWebHdfsPointCut();
+    }
+
+    @Override
+    public Enhancer getEnhancer() {
+        return new HdfsWebHdfsEnhancer();
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPlugin.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPlugin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
 
 import com.alibaba.chaosblade.exec.common.aop.Enhancer;

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
@@ -1,0 +1,46 @@
+package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
+
+import com.alibaba.chaosblade.exec.common.aop.PointCut;
+import com.alibaba.chaosblade.exec.common.aop.matcher.MethodInfo;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.ClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.NameClassMatcher;
+import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
+import javassist.bytecode.AccessFlag;
+import java.util.Arrays;
+
+public class HdfsWebHdfsPointCut implements PointCut {
+    // NameNode handler
+    private static final String CLASS_HDFS_WEBHDFS_METHODS = "org.apache.hadoop.hdfs.server.namenode.web.resources.NamenodeWebHdfsMethods";
+
+    // DataNode handler, including operations such as OPEN, CREATE, APPEND, GETFILECHECKSUM, etc.
+    // private static final String CLASS_HDFS_WEBHDFS_HANDLER = "org.apache.hadoop.hdfs.server.datanode.web.webhdfs.WebHdfsHandler";
+
+    private static final String METHOD_HDFS_WEBHDFS_GET = "get";
+    private static final String METHOD_HDFS_WEBHDFS_PUT = "put";
+    private static final String METHOD_HDFS_WEBHDFS_POST = "post";
+    private static final String METHOD_HDFS_WEBHDFS_DELETE = "delete";
+    private static final String[] TARGET_METHODS = new String[] {
+            METHOD_HDFS_WEBHDFS_GET,
+            METHOD_HDFS_WEBHDFS_PUT,
+            METHOD_HDFS_WEBHDFS_POST,
+            METHOD_HDFS_WEBHDFS_DELETE
+    };
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return new NameClassMatcher(CLASS_HDFS_WEBHDFS_METHODS);
+    }
+
+    @Override
+    public MethodMatcher getMethodMatcher() {
+        MethodMatcher methodMatcher = new MethodMatcher() {
+            @Override
+            public boolean isMatched(String methodName, MethodInfo methodInfo) {
+                return Arrays.stream(TARGET_METHODS).anyMatch(method -> method.equals(methodName))
+                        && (methodInfo.getAccess() & AccessFlag.PUBLIC) == AccessFlag.PUBLIC;
+            }
+        };
+
+        return methodMatcher;
+    }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2013 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs;
 
 import com.alibaba.chaosblade.exec.common.aop.PointCut;
@@ -5,15 +21,11 @@ import com.alibaba.chaosblade.exec.common.aop.matcher.MethodInfo;
 import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.ClassMatcher;
 import com.alibaba.chaosblade.exec.common.aop.matcher.clazz.NameClassMatcher;
 import com.alibaba.chaosblade.exec.common.aop.matcher.method.MethodMatcher;
-import javassist.bytecode.AccessFlag;
 import java.util.Arrays;
 
 public class HdfsWebHdfsPointCut implements PointCut {
     // NameNode handler
     private static final String CLASS_HDFS_WEBHDFS_METHODS = "org.apache.hadoop.hdfs.server.namenode.web.resources.NamenodeWebHdfsMethods";
-
-    // DataNode handler, including operations such as OPEN, CREATE, APPEND, GETFILECHECKSUM, etc.
-    // private static final String CLASS_HDFS_WEBHDFS_HANDLER = "org.apache.hadoop.hdfs.server.datanode.web.webhdfs.WebHdfsHandler";
 
     private static final String METHOD_HDFS_WEBHDFS_GET = "get";
     private static final String METHOD_HDFS_WEBHDFS_PUT = "put";
@@ -33,8 +45,19 @@ public class HdfsWebHdfsPointCut implements PointCut {
 
     @Override
     public MethodMatcher getMethodMatcher() {
-        return (String methodName, MethodInfo methodInfo) ->
-                Arrays.asList(TARGET_METHODS).contains(methodName)
-                && (methodInfo.getAccess() & AccessFlag.PUBLIC) == AccessFlag.PUBLIC;
+        MethodMatcher methodMatcher = new MethodMatcher() {
+            @Override
+            public boolean isMatched(String methodName, MethodInfo methodInfo) {
+                String[] parameterTypes = methodInfo.getParameterTypes();
+                if (parameterTypes == null || parameterTypes.length < 5) {
+                    return false;
+                }
+
+                return Arrays.asList(TARGET_METHODS).contains(methodName)
+                       && String.class.getTypeName().equals(methodInfo.getParameterTypes()[4]);
+            }
+        };
+
+        return methodMatcher;
     }
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/java/com/alibaba/chaosblade/exec/plugin/hdfs/restful/webhdfs/HdfsWebHdfsPointCut.java
@@ -33,14 +33,8 @@ public class HdfsWebHdfsPointCut implements PointCut {
 
     @Override
     public MethodMatcher getMethodMatcher() {
-        MethodMatcher methodMatcher = new MethodMatcher() {
-            @Override
-            public boolean isMatched(String methodName, MethodInfo methodInfo) {
-                return Arrays.stream(TARGET_METHODS).anyMatch(method -> method.equals(methodName))
-                        && (methodInfo.getAccess() & AccessFlag.PUBLIC) == AccessFlag.PUBLIC;
-            }
-        };
-
-        return methodMatcher;
+        return (String methodName, MethodInfo methodInfo) ->
+                Arrays.asList(TARGET_METHODS).contains(methodName)
+                && (methodInfo.getAccess() & AccessFlag.PUBLIC) == AccessFlag.PUBLIC;
     }
 }

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
@@ -1,0 +1,18 @@
+#
+# Copyright 1999-2019 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.chaosblade.exec.plugin.hdfs.restful.httpfs.HdfsHttpFSPlugin
+com.alibaba.chaosblade.exec.plugin.hdfs.restful.webhdfs.HdfsWebHdfsPlugin

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-hdfs/src/main/resources/META-INF/services/com.alibaba.chaosblade.exec.common.aop.Plugin
@@ -1,5 +1,5 @@
 #
-# Copyright 1999-2019 Alibaba Group Holding Ltd.
+# Copyright 1999-2023 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/chaosblade-exec-plugin/pom.xml
+++ b/chaosblade-exec-plugin/pom.xml
@@ -51,6 +51,7 @@
         <module>chaosblade-exec-plugin-zookeeper</module>
         <module>chaosblade-exec-plugin-feign</module>
         <module>chaosblade-exec-plugin-security</module>
+        <module>chaosblade-exec-plugin-hdfs</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
A new plugin for HDFS chaos experiments is introduced in this PR. For now some big data components (hbase, kafka, elasticsearch, zookeeper, etc.) have been supported by ChaosBlade, this new plugin would help to expand the boundary of tool ability to further more.

### Does this pull request fix one issue?
Fixes #319.

### Describe how you did it
The HDFS plugin is compatible with ChaosBlade JVM plugin architecture, which provides two basic experimental actions, delay and throwCustomException by default. In this initial versoin, the plugin focuses on simulating above faults when users try to access HDFS files via restful service. Although there are two different types of implementation in HDFS rest service which sharing the same API, the plugin can automatically adapt itself to inject corresponding faults to the target HDFS process.
In addition to default required action flags, two more optional flags could be assgined by users. One is flag '--file' which the target HDFS file absolute path to be matched with, the other is flag '--op' that would make an experiment to be conducted within the range of certain desired HDFS file operation commands.

### Describe how to verify it

- Command line examples
```
blade create hdfs delay --time 1000  --pid 12345 [--file /hdfs/demo.tmp] [--op open]
blade create hdfs throwCustomException --exception  java.lang.Exception --pid 12345 [--file /hdfs/demo.tmp] [--op open]
```

- Different HDFS restful implementations
When comming to interact with HttpFS rest service, you have to find out which server in HDFS cluster is holding the httpfs service and then invoke blade command on that server. The process ID of httpfs service could pass to the flag '--pid', or just specify flag '--process' with the value 'httpfs'.
When making chaos experiments of WebHDFS rest service, just pick out the ACTIVE namenode in HDFS cluster, and invoke blade command on that server. The namenode process ID should be assigned to the flag '--pid', or you can just mark 'namenode' to the flag '--process'.

### Special notes for reviews
By considering further development of this plugin, such as HDFS API operation support, HDFS command line operation support and so on, I created a package named 'restful' in the project to wrap all current funtionalities, and left flag matcher '--file' under package 'common' for more usage in the furture.