### PR TITLE
fix: Kafka consumer experiment is not effective

### DIFF
--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/src/main/java/com/alibaba/chaosblade/exec/plugin/kafka/consumer/KafkaConsumerEnhancer.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/src/main/java/com/alibaba/chaosblade/exec/plugin/kafka/consumer/KafkaConsumerEnhancer.java
@@ -5,11 +5,13 @@ import com.alibaba.chaosblade.exec.common.aop.EnhancerModel;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.util.ReflectUtil;
 import com.alibaba.chaosblade.exec.plugin.kafka.KafkaConstant;
+import com.alibaba.chaosblade.exec.plugin.kafka.model.ConsumerTopicMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author ljzhxx@gmail.com
@@ -20,45 +22,79 @@ public class KafkaConsumerEnhancer extends BeforeEnhancer implements KafkaConsta
 
     @Override
     public EnhancerModel doBeforeAdvice(ClassLoader classLoader, String className, Object object, Method method, Object[] methodArguments) throws Exception {
-
         if (methodArguments == null || object == null) {
             LOGGER.warn("The necessary parameter is null.");
             return null;
         }
-
-        HashSet<String> topicKeySet = new HashSet<>();
-        String groupId = "";
-        if (POLL.equals(method.getName())) {
-            groupId = ReflectUtil.getFieldValue(object, "groupId", false);
-            Object metadata = ReflectUtil.getFieldValue(object, "metadata", false);
-            Object subscription = ReflectUtil.getFieldValue(metadata, "subscription", false);
-            if (subscription != null) {
-                Object subscriptionList = ReflectUtil.getFieldValue(subscription, "subscription", false);
-                if (subscriptionList != null) {
-                    topicKeySet = (HashSet<String>) subscriptionList;
-                }
-            }else{
-                Map<String, Object> topics = (Map<String, Object>) ReflectUtil.getFieldValue(metadata, "topics", false);
-                Iterator<String> iterator = topics.keySet().iterator();
-                while (iterator.hasNext()){
-                    topicKeySet.add(iterator.next());
-                }
-            }
-        }
-
         MatcherModel matcherModel = new MatcherModel();
-
-        for (String item : topicKeySet) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("consumer topicKey: {}, matcherModel: {}", item, matcherModel.getMatchers());
-            }
-            matcherModel.add(TOPIC_KEY, item);
-        }
-
+        matcherModel.add(CONSUMER_KEY, "true");
+        // groupId
+        String groupId = this.findGroupId(object);
+        matcherModel.add(GROUP_ID_KEY, groupId);
+        // topic
+        Set<String> topicKeySet = this.findTopic(object);
         EnhancerModel enhancerModel = new EnhancerModel(classLoader, matcherModel);
-        enhancerModel.addMatcher(CONSUMER_KEY, "true");
-        enhancerModel.addMatcher(GROUP_ID_KEY, groupId);
+        enhancerModel.addCustomMatcher(TOPIC_KEY, topicKeySet, ConsumerTopicMatcher.getInstance());
+        LOGGER.debug("kafka consumer, groupId = {}, topic = {}", groupId, topicKeySet);
         return enhancerModel;
+    }
+
+    private Set<String> findTopic(Object object) throws Exception {
+        Set<String> topicKeySet = new HashSet<>();
+        Object delegate = ReflectUtil.getFieldValue(object, "delegate", false);
+        Object target = delegate == null ? object : delegate; // 3.6 or 3.7+
+        Object metadata = ReflectUtil.getFieldValue(target, "metadata", false);
+        Object subscription = ReflectUtil.getFieldValue(metadata, "subscription", false);
+        if (subscription != null) {
+            Object subscriptionList = ReflectUtil.getFieldValue(subscription, "subscription", false);
+            if (subscriptionList != null) {
+                topicKeySet.addAll((HashSet<String>) subscriptionList);
+            }
+        } else {
+            Map<String, Object> topics = ReflectUtil.getFieldValue(metadata, "topics", false);
+            if (topics != null) {
+                topicKeySet.addAll(topics.keySet());
+            }
+        }
+        return topicKeySet;
+    }
+
+    private String findGroupId(Object object) throws Exception {
+        Object groupId = ReflectUtil.getFieldValue(object, "groupId", false);
+        if (groupId instanceof String) {
+            return (String) groupId; // 2.5-
+        }
+        if (groupId instanceof Optional) {
+            Optional<String> op = (Optional<String>) groupId;
+            return op.orElse(null); // [2.5, 3.7)
+        }
+        // 3.7+
+        Object delegate = ReflectUtil.getFieldValue(object, "delegate", false);
+        if (delegate == null) {
+            return null;
+        }
+        Object gid = ReflectUtil.getFieldValue(delegate, "groupId", false);
+        if (gid instanceof Optional) {
+            return ((Optional<String>) gid).orElse(null); // 3.7+ ClassicKafkaConsumer/LegacyKafkaConsumer
+        }
+        Object groupMetadata = ReflectUtil.getFieldValue(delegate, "groupMetadata", false);
+        if (groupMetadata instanceof Optional) { // [3.7,3.9) AsyncKafkaConsumer
+            Optional<?> groupMetadataOptional = (Optional<?>) groupMetadata;
+            if (groupMetadataOptional.isPresent()) {
+                // ConsumerGroupMetadata
+                Object meta = groupMetadataOptional.get();
+                return ReflectUtil.getFieldValue(meta, "groupId", false);
+            }
+        }
+        if (groupMetadata instanceof AtomicReference) { // 3.9+ AsyncKafkaConsumer
+            AtomicReference<Optional<?>> ref = (AtomicReference<Optional<?>>) groupMetadata;
+            Optional<?> o = ref.get();
+            if (o != null && o.isPresent()) {
+                Object meta = o.get();
+                return ReflectUtil.getFieldValue(meta, "groupId", false);
+            }
+        }
+        return null;
     }
 }
 

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/src/main/java/com/alibaba/chaosblade/exec/plugin/kafka/model/ConsumerTopicMatcher.java
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-kafka/src/main/java/com/alibaba/chaosblade/exec/plugin/kafka/model/ConsumerTopicMatcher.java
@@ -1,0 +1,27 @@
+package com.alibaba.chaosblade.exec.plugin.kafka.model;
+
+import com.alibaba.chaosblade.exec.common.aop.CustomMatcher;
+
+import java.util.Set;
+
+public class ConsumerTopicMatcher implements CustomMatcher {
+    private static final ConsumerTopicMatcher INSTANCE = new ConsumerTopicMatcher();
+
+    private ConsumerTopicMatcher() {
+    }
+
+    public static ConsumerTopicMatcher getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean match(String commandValue, Object originValue) {
+        Set<String> collection = (Set<String>) originValue;
+        return collection.contains(commandValue);
+    }
+
+    @Override
+    public boolean regexMatch(String commandValue, Object originValue) {
+        return this.match(commandValue, originValue);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. The Kafka consumer experiment is compatible with all client versions; 
2. When the consumer subscribes to multiple topics, it can correctly inject faults through the topic parameter;


### Does this pull request fix one issue?

fixes #339 

### Describe how you did it

i read maybe all version of KafkaConsumer, and found maybe 4 version.

for groupId:
1. [0-2.5), groupId = KafkaConsumer.groupId, type = string;
2. [2.5-3.7)  groupId = KafkaConsumer.groupId, type = Optional<string>;
3. [3.7,+)  KafkaConsumer.delegate = ClassicKafkaConsumer/LegacyKafkaConsumer
 groupId = ClassicKafkaConsumer/LegacyKafkaConsumer.groupId;
4. [3.7,+) KafkaConsumer.delegate = AsyncKafkaConsumer
 groupId = AsyncKafkaConsumer.groupMetadata.groupId;

for topic:
1. [0, 3.7) topics = KafkaConsumer.metadata.topics/subscription
2. [3.7, +) topics = KafkaConsumer.deletgate.metadata.subscription

### Describe how to verify it

1. java code

```java
public static void main(String[] args) {
        Properties properties = new Properties();
        properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
        properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "v24");
        properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
        properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
        properties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
        properties.setProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
        // 3.7+ AsyncKafkaConsumer 
//        properties.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.CONSUMER.name);
        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
        consumer.subscribe(Arrays.asList("testTopic", "abc"));
        while (true) {
            try {
                ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
                System.out.println("consumer receive records = " + records.count());
            } catch (Exception e) {
                e.printStackTrace();
            }
            try {
                Thread.sleep(5000);
            } catch (InterruptedException e) {
            }
        }
    }
```

2. use following blade command:

```
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --topic testTopic -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --topic abc -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --topic a -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --groupId v24 -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --groupId a -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --groupId v24 --topic testTopic -d
./blade create kafka throwCustomException --exception java.lang.Exception --consumer --process app.jar --groupId v24 --topic a -d
```

3. work well and log as below

groupId and topics be extract correctly.
```
DEBUG kafka consumer, groupId = v24, topic = [abc, testTopic]
```

### Special notes for reviews
