### PR TITLE
fearture: add passParamExp for jvm

### DIFF
--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/constant/ModelConstant.java
@@ -35,4 +35,7 @@ public interface ModelConstant {
 
   /** the flag of buisness params */
   String BUSINESS_PARAMS = "b-params";
+
+  /** the flag of param express */
+  String PARAM_EXP_FLAG = "param-express";
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/injection/Injector.java
@@ -29,17 +29,26 @@ import com.alibaba.chaosblade.exec.common.model.action.returnv.UnsupportedReturn
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherModel;
 import com.alibaba.chaosblade.exec.common.util.ModelUtil;
 import com.alibaba.chaosblade.exec.common.util.StringUtil;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import org.mvel2.MVEL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** @author Changjun Xiao */
 public class Injector {
   private static final Logger LOGGER = LoggerFactory.getLogger(Injector.class);
+
+  private static Cache<String, Serializable> EXP_CACHE =
+      CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.MINUTES).build();
 
   /**
    * Inject
@@ -56,7 +65,15 @@ public class Injector {
         continue;
       }
       try {
-        boolean pass = limitAndIncrease(statusMetric);
+        boolean pass =
+            passParamExp(
+                target, model.getMatcher().get(ModelConstant.PARAM_EXP_FLAG), enhancerModel);
+        if (!pass) {
+          LOGGER.info("passParamExp by: {}", model);
+          break;
+        }
+
+        pass = limitAndIncrease(statusMetric);
         if (!pass) {
           LOGGER.info("Limited by: {}", model);
           break;
@@ -132,7 +149,8 @@ public class Injector {
       LOGGER.debug("match key:{} beginning...", keyName);
       // filter effect count and effect percent
       if (keyName.equalsIgnoreCase(ModelConstant.EFFECT_COUNT_MATCHER_NAME)
-          || keyName.equalsIgnoreCase(ModelConstant.EFFECT_PERCENT_MATCHER_NAME)) {
+          || keyName.equalsIgnoreCase(ModelConstant.EFFECT_PERCENT_MATCHER_NAME)
+          || keyName.equalsIgnoreCase(ModelConstant.PARAM_EXP_FLAG)) {
         continue;
       }
 
@@ -177,5 +195,58 @@ public class Injector {
       return false;
     }
     return !matchers.isEmpty();
+  }
+
+  /**
+   * Compare the experiment rule with the date collected by method enhancer
+   *
+   * @param paramExp
+   * @param enhancerModel
+   * @return
+   */
+  private static boolean passParamExp(String target, String paramExp, EnhancerModel enhancerModel) {
+    LOGGER.info("passParamExp target: {} paramExp: {}", target, paramExp);
+    Object[] methodArguments = enhancerModel.getMethodArguments();
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
+          "passParamExp target: {} paramExp: {} methodArguments: {}",
+          target,
+          paramExp,
+          methodArguments);
+    }
+    if (null == methodArguments || methodArguments.length == 0 || StringUtil.isBlank(paramExp)) {
+      return true;
+    }
+
+    Map<String, Object> paramMap = new HashMap<String, Object>(methodArguments.length);
+
+    for (int i = 0; i < methodArguments.length; i++) {
+      paramMap.put("arg" + i, methodArguments[i]);
+    }
+
+    Serializable exp = EXP_CACHE.getIfPresent(paramExp);
+
+    try {
+      if (exp == null) {
+        synchronized (Injector.class) {
+          Serializable compileExpression = MVEL.compileExpression(paramExp);
+          EXP_CACHE.put(paramExp, compileExpression);
+          exp = compileExpression;
+        }
+      }
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("passParamExp exp: {} paramMap: {}", exp, paramMap);
+      }
+      Object result = MVEL.executeExpression(exp, paramMap);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("passParamExp result: {}", result);
+      }
+      if (Boolean.TRUE.equals(result)) {
+        return true;
+      }
+    } catch (Throwable e) {
+      LOGGER.error("matchParamExp err", e);
+    }
+    return false;
   }
 }

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/BaseModelSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/BaseModelSpec.java
@@ -22,6 +22,7 @@ import com.alibaba.chaosblade.exec.common.model.action.DirectlyInjectionAction;
 import com.alibaba.chaosblade.exec.common.model.matcher.EffectCountMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.matcher.EffectPercentMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.matcher.MatcherSpec;
+import com.alibaba.chaosblade.exec.common.model.matcher.ParamExpMatcherSpec;
 import com.alibaba.chaosblade.exec.common.model.prepare.AgentPrepareSpec;
 import com.alibaba.chaosblade.exec.common.model.prepare.PrepareSpec;
 import java.util.ArrayList;
@@ -66,6 +67,8 @@ public abstract class BaseModelSpec implements ModelSpec {
       // add effect matcher
       actionSpec.addMatcherDesc(new EffectCountMatcherSpec());
       actionSpec.addMatcherDesc(new EffectPercentMatcherSpec());
+      // add param exp matcher
+      actionSpec.addMatcherDesc(new ParamExpMatcherSpec());
     }
   }
 

--- a/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/ParamExpMatcherSpec.java
+++ b/chaosblade-exec-common/src/main/java/com/alibaba/chaosblade/exec/common/model/matcher/ParamExpMatcherSpec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.chaosblade.exec.common.model.matcher;
+
+import com.alibaba.chaosblade.exec.common.aop.PredicateResult;
+import com.alibaba.chaosblade.exec.common.constant.ModelConstant;
+
+/** @author Lingjian Xu */
+public class ParamExpMatcherSpec implements MatcherSpec {
+
+  @Override
+  public String getName() {
+    return ModelConstant.PARAM_EXP_FLAG;
+  }
+
+  @Override
+  public String getDesc() {
+    return "The method param express match of chaos experiment in effect";
+  }
+
+  @Override
+  public boolean noArgs() {
+    return false;
+  }
+
+  @Override
+  public boolean required() {
+    return false;
+  }
+
+  @Override
+  public PredicateResult predicate(MatcherModel matcherModel) {
+    return PredicateResult.success();
+  }
+}

--- a/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/dependency-reduced-pom.xml
+++ b/chaosblade-exec-plugin/chaosblade-exec-plugin-jvm/dependency-reduced-pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.7</version>
+      <version>2.15.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -100,6 +100,18 @@
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
       <version>3.2.4</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mvel</groupId>
+      <artifactId>mvel2</artifactId>
+      <version>2.5.2.Final</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.5.0-jre</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,16 @@
             <version>3.2.4</version>
         </dependency>
         <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
+            <version>2.5.2.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.5.0-jre</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR adds a **method parameter expression matching** feature (`passParamExp`) for JVM chaos experiments.

Currently, ChaosBlade's JVM experiments primarily rely on static matching (class name, method name, etc.). However, in real-world business scenarios, we often need to decide whether to inject faults based on **the actual values of method arguments**. For example:
- Inject latency only when `userId > 10000`
- Throw exceptions only for orders with `status.equals("pending")`

This feature allows users to write complex parameter matching rules using MVEL expressions, enabling more precise fault injection control.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
blade create jvm delay --time 3000 --classname com.example.OrderService --methodname processOrder --param-exp "arg0 > 10000"

### Special notes for reviews
